### PR TITLE
Legacy mocha references removed

### DIFF
--- a/packages/azos/test/app-log-tests.js
+++ b/packages/azos/test/app-log-tests.js
@@ -5,7 +5,7 @@
 </FILE_LICENSE>*/
 
 //import { describe, it } from "mocha";
-import { defineUnit as describe, defineCase as it, condir } from "../run.js";
+import { defineUnit as unit, defineCase as cs, condir } from "../run.js";
 import * as aver from "../aver.js";
 import { ILog } from "../ilog.js";
 import * as log from "../log.js";
@@ -23,10 +23,10 @@ class IMemoryLog extends ILog{
   _doWrite(msg){ this.#buffer.push(msg); }
 }
 
-describe("Application", function() {
-  describe("Log", function() {
+unit("Application", function() {
+  unit("Log", function() {
 
-    it("log-mem-buffer",   function() {
+    cs("log-mem-buffer",   function() {
 
       let logBuffer = [];
 
@@ -52,9 +52,9 @@ describe("Application", function() {
   });
 });
 
-describe("LoggingCommon", function() {
+unit("LoggingCommon", function() {
 
-  it(".exceptionToData(new Error())",   function() {
+  cs(".exceptionToData(new Error())",   function() {
     const got = log.exceptionToData(new Error("crap message"));
     condir("new Error()", got);
     aver.areEqual("Error", got["TypeName"]);
@@ -64,7 +64,7 @@ describe("LoggingCommon", function() {
     aver.isTrue(got["StackTrace"].length > 0);
   });
 
-  it(".exceptionToData(throw new Error())",   function() {
+  cs(".exceptionToData(throw new Error())",   function() {
     try{
       throw new Error("crap message");
     } catch(err) {
@@ -78,7 +78,7 @@ describe("LoggingCommon", function() {
     }
   });
 
-  it(".exceptionToData(new AzosError())",   function() {
+  cs(".exceptionToData(new AzosError())",   function() {
     const got = log.exceptionToData(new AzosError("AZ5 msg", "reactor4", null, -1234));
     condir("new AzosError()", got);
     aver.areEqual("AzosError -1234 @ 'reactor4'", got["TypeName"]);
@@ -88,7 +88,7 @@ describe("LoggingCommon", function() {
     aver.isTrue(got["StackTrace"].length > 0);
   });
 
-  it(".exceptionToData(throw new AzosError(nested))",   function() {
+  cs(".exceptionToData(throw new AzosError(nested))",   function() {
     try{
       try{
         throw new AzosError("Inner msg", "site-3", null, 37);

--- a/packages/azos/test/app-log-tests.js
+++ b/packages/azos/test/app-log-tests.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs, condir } from "../run.js";
 import * as aver from "../aver.js";
 import { ILog } from "../ilog.js";

--- a/packages/azos/test/app-mod-tests.js
+++ b/packages/azos/test/app-mod-tests.js
@@ -5,7 +5,7 @@
 </FILE_LICENSE>*/
 
 //import { describe, it } from "mocha";
-import { defineUnit as describe, defineCase as it } from "../run.js";
+import { defineUnit as unit, defineCase as cs } from "../run.js";
 import { ABSTRACT } from "../coreconsts.js"
 import { dispose } from "../types.js";
 import * as aver from "../aver.js";
@@ -48,9 +48,9 @@ class OhioNews extends INews{
 
 
 
-describe("#AppModule", function() {
+unit("#AppModule", function() {
 
-  it("UsNews needs weather",   function() {
+  cs("UsNews needs weather",   function() {
 
     const app = application({
       modules: [
@@ -68,7 +68,7 @@ describe("#AppModule", function() {
     dispose(app);
   });
 
-  it("UsNews fail wo weather",   function() {
+  cs("UsNews fail wo weather",   function() {
     aver.throws(() =>{
         application({
           modules: [
@@ -80,7 +80,7 @@ describe("#AppModule", function() {
   });
 
 
-  it("OhioNews",   function() {
+  cs("OhioNews",   function() {
 
     const app = application({
       modules: [

--- a/packages/azos/test/app-mod-tests.js
+++ b/packages/azos/test/app-mod-tests.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import { ABSTRACT } from "../coreconsts.js"
 import { dispose } from "../types.js";

--- a/packages/azos/test/app.mjs
+++ b/packages/azos/test/app.mjs
@@ -4,7 +4,7 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-import {suite, Runner, cmdArgsCaseFilter, defineUnit, defineCase} from "../run.js";
+import {suite, Runner, cmdArgsCaseFilter, defineUnit as unit, defineCase as cs} from "../run.js";
 import * as aver from "../aver.js";
 
 import "./types-tests.js";
@@ -28,25 +28,25 @@ import "./localization-tests.js";
 
 ////clearSuite();
 
-defineUnit("RunnerSystemTests", function(){
+unit("RunnerSystemTests", function(){
 
-  defineCase("function", function(){
+  cs("function", function(){
     aver.areEqual(4, 2 + 2);
   });
 
-  defineCase("arrow", () => aver.areEqual(5, 2 + 3));
+  cs("arrow", () => aver.areEqual(5, 2 + 3));
 
-  defineCase("async-arrow-instant", async () => aver.areEqual(5, 2 + 3));
-  defineCase("async-arrow-delay", async () => await new Promise(r => setTimeout(r, 250)));
+  cs("async-arrow-instant", async () => aver.areEqual(5, 2 + 3));
+  cs("async-arrow-delay", async () => await new Promise(r => setTimeout(r, 250)));
 
-  defineCase("promise-fun-instant", function(){ return Promise.resolve(123); } );
-  defineCase("promise-fun-delay", function(){ return new Promise(r => setTimeout(r, 250)); });
+  cs("promise-fun-instant", function(){ return Promise.resolve(123); } );
+  cs("promise-fun-delay", function(){ return new Promise(r => setTimeout(r, 250)); });
 
-  defineUnit("SkippedUnitWhichWillNeverRun", function(){
-    defineCase("never-run", function(){  });
+  unit("SkippedUnitWhichWillNeverRun", function(){
+    cs("never-run", function(){  });
   }, () => true);
 
-  defineCase("this-case-will-be-skipped", function(){  }, () => true);
+  cs("this-case-will-be-skipped", function(){  }, () => true);
 
 });
 

--- a/packages/azos/test/aver-tests.js
+++ b/packages/azos/test/aver-tests.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../aver.js";
 

--- a/packages/azos/test/conf-tests.js
+++ b/packages/azos/test/conf-tests.js
@@ -5,15 +5,15 @@
 </FILE_LICENSE>*/
 
 //import { describe, it } from "mocha";
-import { defineUnit as describe, defineCase as it } from "../run.js";
+import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as aver from "../aver.js";
 import { $ } from "../linq.js";
 import * as sut from "../conf.js";
 
-describe("Configuration", function() {
+unit("Configuration", function() {
 
-  describe("config", function() {
-    it("config()",   function() {
+  unit("config", function() {
+    cs("config()",   function() {
       const cfg = sut.config({a: 1, b: 2, c: true});
       aver.areEqual(3, cfg.root.count);
       aver.areEqual(1, cfg.root.get("a"));
@@ -22,16 +22,16 @@ describe("Configuration", function() {
     });
   });
 
-  describe(".ctor", function() {
+  unit(".ctor", function() {
 
-    it("undef",        () => aver.throws(()=> new sut.Configuration(undefined), "init content"));
-    it("null",         () => aver.throws(()=> new sut.Configuration(null), "init content"));
-    it("empty string", () => aver.throws(() => new sut.Configuration(""), "init content"));
-    it("bad json string", () => aver.throws(() => new sut.Configuration("{ bad json"), "init content"));
-    it("non object",   () => aver.throws(() => new sut.Configuration(123), "init content"));
+    cs("undef",        () => aver.throws(()=> new sut.Configuration(undefined), "init content"));
+    cs("null",         () => aver.throws(()=> new sut.Configuration(null), "init content"));
+    cs("empty string", () => aver.throws(() => new sut.Configuration(""), "init content"));
+    cs("bad json string", () => aver.throws(() => new sut.Configuration("{ bad json"), "init content"));
+    cs("non object",   () => aver.throws(() => new sut.Configuration(123), "init content"));
 
 
-    it("from object",   function() {
+    cs("from object",   function() {
       const cfg = new sut.Configuration({a: 1, b: 2, c: true});
       aver.areEqual(3, cfg.root.count);
       aver.areEqual(1, cfg.root.get("a"));
@@ -39,7 +39,7 @@ describe("Configuration", function() {
       aver.areEqual(true, cfg.root.get("c"));
     });
 
-    it("from string",   function() {
+    cs("from string",   function() {
       const cfg = new sut.Configuration('{"a": 1, "b": 2, "c": true}');
       aver.areEqual(3, cfg.root.count);
       aver.areEqual(1, cfg.root.get("a"));
@@ -47,7 +47,7 @@ describe("Configuration", function() {
       aver.areEqual(true, cfg.root.get("c"));
     });
 
-    it(".content",   function() {
+    cs(".content",   function() {
       const cfg = new sut.Configuration('{"a": 1, "b": -2}');
       aver.areEqual(2, cfg.root.count);
       aver.areEqual(1, cfg.root.get("a"));
@@ -62,91 +62,91 @@ describe("Configuration", function() {
 });
 
 
-describe("ConfigNode", function() {
+unit("ConfigNode", function() {
 
-  it("toString()",   function() {
+  cs("toString()",   function() {
     const cfg = sut.config({a: 1, b: 2, c: true});
     //console.info(cfg.root.toString());
     aver.areEqual("ConfigNode('/', {3})", cfg.root.toString());
   });
 
-  it("configuration",   function() {
+  cs("configuration",   function() {
     const cfg = sut.config({a: 1, b: 2, c: true});
     aver.areEqual(cfg, cfg.root.configuration);
   });
 
-  it("name",   function() {
+  cs("name",   function() {
     const cfg = sut.config({a: 1, b: {f: true}});
     aver.areEqual("/", cfg.root.name);
     aver.areEqual("b", cfg.root.get("b").name);
   });
 
-  it("parent",   function() {
+  cs("parent",   function() {
     const cfg = sut.config({a: 1, b: {f: true}});
     aver.areEqual(cfg.root, cfg.root.get("b").parent);
   });
 
-  it("isSection|isArray",   function() {
+  cs("isSection|isArray",   function() {
     const cfg = sut.config({a: [1,2,3], b: {f: true}});
     aver.isTrue(cfg.root.get("a").isArray);
     aver.isTrue(cfg.root.get("b").isSection);
   });
 
-  it("path",   function() {
+  cs("path",   function() {
     const cfg = sut.config({a: 1, b: {f: {q: [ {a1: {}}, [{ok: false}] ]}}});
     aver.areEqual("/b", cfg.root.get("b").path);
     aver.areEqual("/b/f", cfg.root.get("b").get("f").path);
     aver.areEqual("/b/f/q/#0/a1", cfg.root.get("b").get("f").get("q").get("#0").get("a1").path);
   });
 
-  it("get() null/undefined values",   function() {
+  cs("get() null/undefined values",   function() {
     const cfg = sut.config({a: 1, b: null, c: undefined});
     aver.areEqual(1, cfg.root.get("a"));
     aver.areEqual(null, cfg.root.get("b"));
     aver.areEqual(undefined, cfg.root.get("c"));
   });
 
-  it("get()",   function() {
+  cs("get()",   function() {
     const cfg = sut.config({a: 1, b: 2, c: true});
     aver.areEqual(undefined, cfg.root.get());
   });
 
-  it("get(null)",   function() {
+  cs("get(null)",   function() {
     const cfg = sut.config({a: 1, b: 2, c: true});
     aver.areEqual(undefined, cfg.root.get(null));
   });
 
-  it("get('')",   function() {
+  cs("get('')",   function() {
     const cfg = sut.config({a: 1, b: 2, c: true});
     aver.areEqual(undefined, cfg.root.get(""));
   });
 
-  it("get('notExist')",   function() {
+  cs("get('notExist')",   function() {
     const cfg = sut.config({a: 1, b: 2, c: true});
     aver.areEqual(undefined, cfg.root.get("notExist"));
   });
 
-  it("get('notExist', 'a')",   function() {
+  cs("get('notExist', 'a')",   function() {
     const cfg = sut.config({a: 1, b: 2, c: true});
     aver.areEqual(1, cfg.root.get("notExist", "a"));
   });
 
-  it("get('notExist', 'b', 'a')",   function() {
+  cs("get('notExist', 'b', 'a')",   function() {
     const cfg = sut.config({a: 1, b: 2, c: true});
     aver.areEqual(2, cfg.root.get("notExist", "b", "a"));
   });
 
-  it("get('notExist', null, 'a')",   function() {
+  cs("get('notExist', null, 'a')",   function() {
     const cfg = sut.config({a: 11, b: 22, c: true});
     aver.areEqual(11, cfg.root.get("notExist", null, "a"));
   });
 
-  it("get('notExist', undefined, 'a')",   function() {
+  cs("get('notExist', undefined, 'a')",   function() {
     const cfg = sut.config({a: 11, b: 22, c: true});
     aver.areEqual(11, cfg.root.get("notExist", undefined, "a"));
   });
 
-  it("get(null|undef combinations)",   function() {
+  cs("get(null|undef combinations)",   function() {
     const cfg = sut.config({a: 11, b: 22, c: true});
     aver.areEqual(11, cfg.root.get(undefined, "notExist", undefined, "a"));
     aver.areEqual(11, cfg.root.get(null, "notExist", undefined, "a"));
@@ -158,7 +158,7 @@ describe("ConfigNode", function() {
     aver.areEqual(11, cfg.root.get("a", ...a));
   });
 
-  it("getVerbatim(null|undef combinations)",   function() {
+  cs("getVerbatim(null|undef combinations)",   function() {
     const cfg = sut.config({a: 11, b: 22, c: true});
     aver.areEqual(11, cfg.root.getVerbatim(undefined, "notExist", undefined, "a"));
     aver.areEqual(11, cfg.root.getVerbatim(null, "notExist", undefined, "a"));
@@ -170,7 +170,7 @@ describe("ConfigNode", function() {
     aver.areEqual(11, cfg.root.getVerbatim("a", ...a));
   });
 
-  it("get(section)",   function() {
+  cs("get(section)",   function() {
     const cfg = sut.config({a: 11, b: {d: -9, z: 78.12}, c: true});
     aver.areEqual(11, cfg.root.get("a"));
     aver.isOf(cfg.root.get("b"), sut.ConfigNode);
@@ -179,7 +179,7 @@ describe("ConfigNode", function() {
   });
 
 
-  it("complex structure and nav",   function() {
+  cs("complex structure and nav",   function() {
     const cfg = sut.config({
       v: null,
       a: {
@@ -223,7 +223,7 @@ describe("ConfigNode", function() {
     aver.areEqual("little bug", cfg.root.nav("/a/section1/array").get("2").get("0").nav("string name"));
   });
 
-  it("iterator",   function() {
+  cs("iterator",   function() {
     const cfg = sut.config({
       abba: 11,
       bubba: {d: -9, z: 78.12},
@@ -252,7 +252,7 @@ describe("ConfigNode", function() {
     aver.areIterablesEquivalent([1, 5, cfg.root.nav("/dole/2")], doleItems.select(one => one.val));
   });
 
-  it("var-path-eval",   function() {
+  cs("var-path-eval",   function() {
     const cfg = sut.config({
       id: "a1bold",
       paths: {
@@ -298,7 +298,7 @@ describe("ConfigNode", function() {
     aver.areEqual("~/data-a1bold", cfg.root.get("paths_Alias2").get("data"));
   });
 
-  it("verbatim",   function() {
+  cs("verbatim",   function() {
     const cfg = sut.config({
       id: "a1bold",
       paths: new sut.Verbatim({
@@ -330,7 +330,7 @@ describe("ConfigNode", function() {
 
   });
 
-  it("verbatim-2",   function() {
+  cs("verbatim-2",   function() {
 
     class A{  [sut.GET_CONFIG_VERBATIM_VALUE](){ return 1234;}  }
     class B{    }
@@ -349,7 +349,7 @@ describe("ConfigNode", function() {
   });
 
 
-  it("var-recursion",   function() {
+  cs("var-recursion",   function() {
     const cfg = sut.config({
       id: "a1bold",
       paths: {
@@ -364,7 +364,7 @@ describe("ConfigNode", function() {
   });
 
 
-  it("getNodeAttrOrValue()",   function() {
+  cs("getNodeAttrOrValue()",   function() {
     aver.areEqual(1, sut.getNodeAttrOrValue(1, "a"));
     aver.areEqual("yes no", sut.getNodeAttrOrValue("yes no", "a"));
     aver.areEqual(-897.12, sut.getNodeAttrOrValue(sut.config({a: -897.12}), "a"));
@@ -374,7 +374,7 @@ describe("ConfigNode", function() {
     aver.areEqual("zzz", sut.getNodeAttrOrValue(sut.config({a: "$(b)", b: "zzz"}), "no", "cant", "a"));
   });
 
-  it("getVerbatimNodeAttrOrValue()",   function() {
+  cs("getVerbatimNodeAttrOrValue()",   function() {
     aver.areEqual(1, sut.getVerbatimNodeAttrOrValue(1, "a"));
     aver.areEqual("yes no", sut.getVerbatimNodeAttrOrValue("yes no", "a"));
     aver.areEqual(-897.12, sut.getVerbatimNodeAttrOrValue(sut.config({a: -897.12}), "a"));
@@ -385,9 +385,9 @@ describe("ConfigNode", function() {
   });
 
 
-  describe("Flatten", function(){
+  unit("Flatten", function(){
 
-    it("map-simple",  function() {
+    cs("map-simple",  function() {
       const cfg = sut.config({ a: 1, b: 2, s: "hello" });
 
       const got = cfg.root.flatten();
@@ -397,7 +397,7 @@ describe("ConfigNode", function() {
       aver.areEqual("hello", got.s);
     });
 
-    it("map-simple-var",  function() {
+    cs("map-simple-var",  function() {
       const cfg = sut.config({ a: 1, b: 2, c: "$(b)-$(a)" });
 
       const got = cfg.root.flatten();
@@ -407,7 +407,7 @@ describe("ConfigNode", function() {
       aver.areEqual("2-1", got.c);
     });
 
-    it("map-simple-var-verbatim",  function() {
+    cs("map-simple-var-verbatim",  function() {
       const cfg = sut.config({ a: 1, b: 2, c: "$(b)-$(a)" });
 
       const got = cfg.root.flatten(true);
@@ -417,7 +417,7 @@ describe("ConfigNode", function() {
       aver.areEqual("$(b)-$(a)", got.c);
     });
 
-    it("array-simple",  function() {
+    cs("array-simple",  function() {
       const cfg = sut.config({d: [1, 2, "hello"]});
 
       const got = cfg.root.get("d").flatten();
@@ -427,7 +427,7 @@ describe("ConfigNode", function() {
       aver.areEqual("hello", got[2]);
     });
 
-    it("array-simple-var",  function() {
+    cs("array-simple-var",  function() {
       const cfg = sut.config({d: [1, 2, "$(1)-$(0)"]});
 
       const got = cfg.root.get("d").flatten();
@@ -437,7 +437,7 @@ describe("ConfigNode", function() {
       aver.areEqual("2-1", got[2]);
     });
 
-    it("array-simple-var-verbatim",  function() {
+    cs("array-simple-var-verbatim",  function() {
       const cfg = sut.config({d: [1, 2, "$(1)-$(0)"]});
 
       const got = cfg.root.get("d").flatten(true);
@@ -448,7 +448,7 @@ describe("ConfigNode", function() {
     });
 
 
-    it("complex",  function() {
+    cs("complex",  function() {
       const cfg = sut.config({
          a: 10,
          b: -275,
@@ -482,7 +482,7 @@ describe("ConfigNode", function() {
       aver.areEqual(-789.234, got.d.z[1].b);
     });
 
-    it("complex-getFlatNode()",  function() {
+    cs("complex-getFlatNode()",  function() {
       const cfg = sut.config({
          a: 10,
          b: -275,
@@ -512,7 +512,7 @@ describe("ConfigNode", function() {
   });
 
 
-  it("getChildren()",   function() {
+  cs("getChildren()",   function() {
     const cfg = sut.config({
       a: {x: 123},
       b: [{x: -11}, {x: -22}],
@@ -585,294 +585,294 @@ describe("ConfigNode", function() {
     vDate1: new Date("2017-10-19")
   }).root;
 
-  it("getString(undefined)",   function() {
+  cs("getString(undefined)",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getString("vUndefined"));
     aver.areEqual("Mister X!", cfgGetAccessors.getString("vUndefined", "Mister X!"));
   });
 
-  it("getString(null)",   function() {
+  cs("getString(null)",   function() {
     aver.areEqual(null, cfgGetAccessors.getString("vNull"));
     aver.areEqual("Mister Y!", cfgGetAccessors.getString("vNull", "Mister Y!"));
   });
 
-  it("getString('')",   function() {
+  cs("getString('')",   function() {
     aver.areEqual("", cfgGetAccessors.getString("vStringEmpty"));
     aver.areEqual("zzz", cfgGetAccessors.getString("vStringEmpty", "zzz"));
     aver.areEqual(" ", cfgGetAccessors.getString("vStringSpace"));
     aver.areEqual("nnn", cfgGetAccessors.getString("vStringSpace", "nnn"));
   });
 
-  it("getString(int)",   function() {
+  cs("getString(int)",   function() {
     aver.areEqual(0xfaca.toString(), cfgGetAccessors.getString("vInt3"));
     aver.areEqual(0xfaca.toString(), cfgGetAccessors.getString("vInt3", "kuku"));
   });
 
-  it("getString(money)",   function() {
+  cs("getString(money)",   function() {
     aver.areEqual("-12345.12345", cfgGetAccessors.getString("vMoney3"));
     aver.areEqual("-12345.12345", cfgGetAccessors.getString("vMoney3","smoke"));
   });
 
-  it("getBool(undefined)",   function() {
+  cs("getBool(undefined)",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getBool("vUndefined"));
     aver.areEqual(true, cfgGetAccessors.getBool("vUndefined", true));
   });
 
-  it("getBool(null)",   function() {
+  cs("getBool(null)",   function() {
     aver.areEqual(false, cfgGetAccessors.getBool("vNull"));
     aver.areEqual(false, cfgGetAccessors.getBool("vNull", true));
   });
 
-  it("getBool(' ')",   function() {
+  cs("getBool(' ')",   function() {
     aver.areEqual(false, cfgGetAccessors.getBool("vStringSpace"));
     aver.areEqual(false, cfgGetAccessors.getBool("vStringSpace", true));
   });
 
-  it("getBool(str1)",   function() {
+  cs("getBool(str1)",   function() {
     aver.areEqual(true, cfgGetAccessors.getBool("vStringBool1"));
     aver.areEqual(true, cfgGetAccessors.getBool("vStringBool1", false));
   });
 
-  it("getBool(str2)",   function() {
+  cs("getBool(str2)",   function() {
     aver.areEqual(true, cfgGetAccessors.getBool("vStringBool2"));
     aver.areEqual(true, cfgGetAccessors.getBool("vStringBool2", false));
   });
 
-  it("getBool(str3)",   function() {
+  cs("getBool(str3)",   function() {
     aver.areEqual(true, cfgGetAccessors.getBool("vStringBool3"));
     aver.areEqual(true, cfgGetAccessors.getBool("vStringBool3", false));
   });
 
-  it("getBool(bool1)",   function() {
+  cs("getBool(bool1)",   function() {
     aver.areEqual(true, cfgGetAccessors.getBool("vBool1"));
     aver.areEqual(true, cfgGetAccessors.getBool("vBool1", false));
   });
 
-  it("getBool(bool2)",   function() {
+  cs("getBool(bool2)",   function() {
     aver.areEqual(true, cfgGetAccessors.getBool("vBool2"));
     aver.areEqual(true, cfgGetAccessors.getBool("vBool2", false));
   });
 
-  it("getBool(bool3)",   function() {
+  cs("getBool(bool3)",   function() {
     aver.areEqual(false, cfgGetAccessors.getBool("vBool3"));
     aver.areEqual(false, cfgGetAccessors.getBool("vBool3", true));
   });
 
 
-  it("getTriBool(undefined)",   function() {
+  cs("getTriBool(undefined)",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getTriBool("vUndefined"));
     aver.areEqual(undefined, cfgGetAccessors.getTriBool("vUndefined", true));
   });
 
-  it("getTriBool(null)",   function() {
+  cs("getTriBool(null)",   function() {
     aver.areEqual(false, cfgGetAccessors.getTriBool("vNull"));
     aver.areEqual(false, cfgGetAccessors.getTriBool("vNull", true));
   });
 
-  it("getTriBool(' ')",   function() {
+  cs("getTriBool(' ')",   function() {
     aver.areEqual(false, cfgGetAccessors.getTriBool("vStringSpace"));
     aver.areEqual(false, cfgGetAccessors.getTriBool("vStringSpace", true));
   });
 
-  it("getTriBool(str1)",   function() {
+  cs("getTriBool(str1)",   function() {
     aver.areEqual(true, cfgGetAccessors.getTriBool("vStringBool1"));
     aver.areEqual(true, cfgGetAccessors.getTriBool("vStringBool1", false));
   });
 
-  it("getTriBool(str2)",   function() {
+  cs("getTriBool(str2)",   function() {
     aver.areEqual(true, cfgGetAccessors.getTriBool("vStringBool2"));
     aver.areEqual(true, cfgGetAccessors.getTriBool("vStringBool2", false));
   });
 
-  it("getTriBool(str3)",   function() {
+  cs("getTriBool(str3)",   function() {
     aver.areEqual(true, cfgGetAccessors.getTriBool("vStringBool3"));
     aver.areEqual(true, cfgGetAccessors.getTriBool("vStringBool3", false));
   });
 
-  it("getInt(undefined)",   function() {
+  cs("getInt(undefined)",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getInt("vUndefined"));
     aver.areEqual(123, cfgGetAccessors.getInt("vUndefined", 123));
   });
 
-  it("getInt(null)",   function() {
+  cs("getInt(null)",   function() {
     aver.areEqual(0, cfgGetAccessors.getInt("vNull"));
     aver.areEqual(0, cfgGetAccessors.getInt("vNull", 456));
   });
 
-  it("getInt('')",   function() {
+  cs("getInt('')",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getInt("vStringEmpty"));
     aver.areEqual(456, cfgGetAccessors.getInt("vStringEmpty", 456));
   });
 
-  it("getInt(' ')",   function() {
+  cs("getInt(' ')",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getInt("vStringSpace"));
     aver.areEqual(-456, cfgGetAccessors.getInt("vStringSpace", -456));
   });
 
-  it("getInt(str1)",   function() {
+  cs("getInt(str1)",   function() {
     aver.areEqual(9, cfgGetAccessors.getInt("vStringInt1"));
     aver.areEqual(9, cfgGetAccessors.getInt("vStringInt1", -456));
   });
 
-  it("getInt(str2)",   function() {
+  cs("getInt(str2)",   function() {
     aver.areEqual(9, cfgGetAccessors.getInt("vStringInt2"));
     aver.areEqual(9, cfgGetAccessors.getInt("vStringInt2", -456));
   });
 
-  it("getInt(str3)",   function() {
+  cs("getInt(str3)",   function() {
     aver.areEqual(-9, cfgGetAccessors.getInt("vStringInt3"));
     aver.areEqual(-9, cfgGetAccessors.getInt("vStringInt3", -456));
   });
 
-  it("getInt(int1)",   function() {
+  cs("getInt(int1)",   function() {
     aver.areEqual(123, cfgGetAccessors.getInt("vInt1"));
     aver.areEqual(123, cfgGetAccessors.getInt("vInt1", -456));
   });
 
-  it("getInt(int2)",   function() {
+  cs("getInt(int2)",   function() {
     aver.areEqual(-123, cfgGetAccessors.getInt("vInt2"));
     aver.areEqual(-123, cfgGetAccessors.getInt("vInt2", -456));
   });
 
-  it("getInt(int3)",   function() {
+  cs("getInt(int3)",   function() {
     aver.areEqual(0xfaca, cfgGetAccessors.getInt("vInt3"));
     aver.areEqual(0xfaca, cfgGetAccessors.getInt("vInt3", -456));
   });
 
-  it("getReal(undefined)",   function() {
+  cs("getReal(undefined)",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getReal("vUndefined"));
     aver.areEqual(123e5, cfgGetAccessors.getReal("vUndefined", 123e5));
   });
 
-  it("getReal(null)",   function() {
+  cs("getReal(null)",   function() {
     aver.areEqual(0, cfgGetAccessors.getReal("vNull"));
     aver.areEqual(0, cfgGetAccessors.getReal("vNull", 456.1));
   });
 
-  it("getReal('')",   function() {
+  cs("getReal('')",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getReal("vStringEmpty"));
     aver.areEqual(456.2, cfgGetAccessors.getReal("vStringEmpty", 456.2));
   });
 
-  it("getReal(' ')",   function() {
+  cs("getReal(' ')",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getReal("vStringSpace"));
     aver.areEqual(-456.03, cfgGetAccessors.getReal("vStringSpace", -456.03));
   });
 
-  it("getReal(str1)",   function() {
+  cs("getReal(str1)",   function() {
     aver.areEqual(1.0, cfgGetAccessors.getReal("vStringReal1"));
     aver.areEqual(1.0, cfgGetAccessors.getReal("vStringReal1", -456.02));
   });
 
-  it("getReal(str2)",   function() {
+  cs("getReal(str2)",   function() {
     aver.areEqual(-1.0, cfgGetAccessors.getReal("vStringReal2"));
     aver.areEqual(-1.0, cfgGetAccessors.getReal("vStringReal2", -456.03));
   });
 
-  it("getReal(str3)",   function() {
+  cs("getReal(str3)",   function() {
     aver.areEqual(-1e5, cfgGetAccessors.getReal("vStringReal3"));
     aver.areEqual(-1e5, cfgGetAccessors.getReal("vStringReal3", -456.04));
   });
 
-  it("getReal(r1)",   function() {
+  cs("getReal(r1)",   function() {
     aver.areEqual(123.0, cfgGetAccessors.getReal("vReal1"));
     aver.areEqual(123.0, cfgGetAccessors.getReal("vReal1", -456.1));
   });
 
-  it("getReal(r2)",   function() {
+  cs("getReal(r2)",   function() {
     aver.areEqual(-123.0, cfgGetAccessors.getReal("vReal2"));
     aver.areEqual(-123.0, cfgGetAccessors.getReal("vReal2", -456.2));
   });
 
-  it("getReal(r3)",   function() {
+  cs("getReal(r3)",   function() {
     aver.areEqual(-5e-9, cfgGetAccessors.getReal("vReal3"));
     aver.areEqual(-5e-9, cfgGetAccessors.getReal("vReal3", -456.3));
   });
 
 
-  it("getMoney(undefined)",   function() {
+  cs("getMoney(undefined)",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getMoney("vUndefined"));
     aver.areEqual(100.18, cfgGetAccessors.getMoney("vUndefined", 100.18));
   });
 
-  it("getMoney(null)",   function() {
+  cs("getMoney(null)",   function() {
     aver.areEqual(0, cfgGetAccessors.getMoney("vNull"));
     aver.areEqual(0, cfgGetAccessors.getMoney("vNull", 456.1));
   });
 
-  it("getMoney('')",   function() {
+  cs("getMoney('')",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getMoney("vStringEmpty"));
     aver.areEqual(-300.12, cfgGetAccessors.getMoney("vStringEmpty", -300.12));
   });
 
-  it("getMoney(' ')",   function() {
+  cs("getMoney(' ')",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getMoney("vStringSpace"));
     aver.areEqual(-456.03, cfgGetAccessors.getMoney("vStringSpace", -456.03));
   });
 
-  it("getMoney(str1)",   function() {
+  cs("getMoney(str1)",   function() {
     aver.areEqual(1.0, cfgGetAccessors.getMoney("vStringMoney1"));
     aver.areEqual(1.0, cfgGetAccessors.getMoney("vStringMoney1", -456.02));
   });
 
-  it("getMoney(str2)",   function() {
+  cs("getMoney(str2)",   function() {
     aver.areEqual(-1.01, cfgGetAccessors.getMoney("vStringMoney2"));
     aver.areEqual(-1.01, cfgGetAccessors.getMoney("vStringMoney2", -456.03));
   });
 
-  it("getMoney(str3)",   function() {
+  cs("getMoney(str3)",   function() {
     aver.areEqual(12345.1234, cfgGetAccessors.getMoney("vStringMoney3"));
     aver.areEqual(12345.1234, cfgGetAccessors.getMoney("vStringMoney3", -456.04));
   });
 
-  it("getMoney(m1)",   function() {
+  cs("getMoney(m1)",   function() {
     aver.areEqual(123.0, cfgGetAccessors.getMoney("vMoney1"));
     aver.areEqual(123.0, cfgGetAccessors.getMoney("vMoney1", -456.1));
   });
 
-  it("getMoney(m2)",   function() {
+  cs("getMoney(m2)",   function() {
     aver.areEqual(-123.0012, cfgGetAccessors.getMoney("vMoney2"));
     aver.areEqual(-123.0012, cfgGetAccessors.getMoney("vMoney2", -456.2));
   });
 
-  it("getMoney(m3)",   function() {
+  cs("getMoney(m3)",   function() {
     aver.areEqual(-12345.1234, cfgGetAccessors.getMoney("vMoney3"));
     aver.areEqual(-12345.1234, cfgGetAccessors.getMoney("vMoney3", -456.3));
   });
 
 
 
-  it("getDate(undefined)",   function() {
+  cs("getDate(undefined)",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getDate("vUndefined"));
     aver.areEqual(1980, cfgGetAccessors.getDate("vUndefined", new Date("1980-02-21")).getUTCFullYear());
   });
 
-  it("getDate(null)",   function() {
+  cs("getDate(null)",   function() {
     aver.areEqual(1970, cfgGetAccessors.getDate("vNull").getUTCFullYear());
     aver.areEqual(1970, cfgGetAccessors.getDate("vNull", new Date("1980-02-21")).getUTCFullYear());
   });
 
-  it("getDate('')",   function() {
+  cs("getDate('')",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getDate("vStringEmpty"));
     aver.areEqual(-300.12, cfgGetAccessors.getDate("vStringEmpty", -300.12));
   });
 
-  it("getDate(' ')",   function() {
+  cs("getDate(' ')",   function() {
     aver.areEqual(undefined, cfgGetAccessors.getDate("vStringSpace"));
     aver.areEqual(-456.03, cfgGetAccessors.getDate("vStringSpace", -456.03));
   });
 
-  it("getDate(str1)",   function() {
+  cs("getDate(str1)",   function() {
     aver.areEqual(2021, cfgGetAccessors.getDate("vStringDate1").getFullYear());
     aver.areEqual(2021, cfgGetAccessors.getDate("vStringDate1", new Date("1980-02-21")).getUTCFullYear());
   });
 
-  it("getDate(str2)",   function() {
+  cs("getDate(str2)",   function() {
     aver.areEqual(2018, cfgGetAccessors.getDate("vStringDate2").getFullYear());
     aver.areEqual(2018, cfgGetAccessors.getDate("vStringDate2", new Date("1980-02-21")).getUTCFullYear());
   });
 
 
-  it("getDate(d1)",   function() {
+  cs("getDate(d1)",   function() {
     //console.dir(cfgGetAccessors.getString("vDate1"));
     aver.areEqual(2017, cfgGetAccessors.getDate("vDate1").getFullYear());
     aver.areEqual(2017, cfgGetAccessors.getDate("vDate1",  new Date("1980-02-21")).getUTCFullYear());
@@ -917,9 +917,9 @@ class ConfMockStandalone {
   get args(){ return this.#args;}
 }
 
-describe("Config::MakeNew", function() {
+unit("Config::MakeNew", function() {
 
-  it("makeA",   function() {
+  cs("makeA",   function() {
     const cfg = sut.config({
       type: ConfMockA,
       name: "MockA",
@@ -933,7 +933,7 @@ describe("Config::MakeNew", function() {
     aver.areEqual(99, got.age);
   });
 
-  it("makeB",   function() {
+  cs("makeB",   function() {
     const cfg = sut.config({
       type: ConfMockB,
       name: "MockB",
@@ -947,7 +947,7 @@ describe("Config::MakeNew", function() {
     aver.areEqual(1980, got.dob.getFullYear());
   });
 
-  it("makeC",   function() {
+  cs("makeC",   function() {
     const cfg = sut.config({
       type: ConfMockC,
       name: "MockC",
@@ -964,25 +964,25 @@ describe("Config::MakeNew", function() {
     aver.areEqual(1999, got.dob.getFullYear());
   });
 
-  it("makeWrongSubtype",   function() {
+  cs("makeWrongSubtype",   function() {
     const cfg = sut.config({ type: ConfMockStandalone });
     aver.throws(() => sut.makeNew(IConfMock, cfg.root), "is not of expected base");
   });
 
-  it("useFactoryFunction",   function() {
+  cs("useFactoryFunction",   function() {
     const got = sut.makeNew(Object, ConfMockStandalone);
     aver.isOf(got, ConfMockStandalone);
     aver.areEqual(0, got.args.length);
   });
 
-  it("useFactoryFunction ctor args",   function() {
+  cs("useFactoryFunction ctor args",   function() {
     const got = sut.makeNew(Object, ConfMockStandalone, null, null, [1, true, 'abc']);
     aver.isOf(got, ConfMockStandalone);
     aver.areEqual(3, got.args.length);
     aver.areArraysEquivalent([1, true, 'abc'], got.args);
   });
 
-  it("useFactoryFunction ctor args with director",   function() {
+  cs("useFactoryFunction ctor args with director",   function() {
     const dir = {a: 1};
 
     const got = sut.makeNew(Object, ConfMockStandalone, dir, null, [1, true, 'abc']);
@@ -991,7 +991,7 @@ describe("Config::MakeNew", function() {
     aver.areArraysEquivalent([dir, 1, true, 'abc'], got.args);
   });
 
-  it("standalone cfg dir args",   function() {
+  cs("standalone cfg dir args",   function() {
     const dir = {a: 1};
     const cfg = sut.config({ type: ConfMockStandalone });
     const got = sut.makeNew(Object, cfg.root, dir, null, [-1, true, 'abcd']);
@@ -1000,7 +1000,7 @@ describe("Config::MakeNew", function() {
     aver.areArraysEquivalent([dir, cfg.root, -1, true, 'abcd'], got.args);
   });
 
-  it("standalone cfg dir default type args",   function() {
+  cs("standalone cfg dir default type args",   function() {
     const dir = {a: 1};
     const cfg = sut.config({ x: 1 });
     const got = sut.makeNew(Object, cfg.root, dir, ConfMockStandalone, [-1, true, 'abcd']);
@@ -1009,7 +1009,7 @@ describe("Config::MakeNew", function() {
     aver.areArraysEquivalent([dir, cfg.root, -1, true, 'abcd'], got.args);
   });
 
-  it("standalone missing dflt type",   function() {
+  cs("standalone missing dflt type",   function() {
     const dir = {a: 1};
     const cfg = sut.config({ x: 1 });
     aver.throws(() => sut.makeNew(Object, cfg.root, dir, undefined, [-1, true, 'abcd']), "cls was not supplied");
@@ -1018,7 +1018,7 @@ describe("Config::MakeNew", function() {
 });
 
 
-describe("Config::Performance", function() {
+unit("Config::Performance", function() {
 
   const cfgJson =`{
     "a": 1, "b": true, "c": false, "d": null, "e": -9e3, "msg": "loaded from json",
@@ -1040,7 +1040,7 @@ describe("Config::Performance", function() {
     }`;
 
 
-  it("from Json",   function() { // 75K ops/sec on OCTOD
+  cs("from Json",   function() { // 75K ops/sec on OCTOD
     console.time("cfg");
     for(let i=0; i<10_000; i++){
       const cfg = sut.config(cfgJson);
@@ -1050,7 +1050,7 @@ describe("Config::Performance", function() {
 
   });
 
-  it("navigate",   function() { // 80K ops/sec on OCTOD
+  cs("navigate",   function() { // 80K ops/sec on OCTOD
     console.time("cfg");
     const cfg = sut.config(cfgJson);
     for(let i=0; i<10_000; i++){
@@ -1060,7 +1060,7 @@ describe("Config::Performance", function() {
 
   });
 
-  it("makeNew",   function() { // 200K ops/sec on OCTOD
+  cs("makeNew",   function() { // 200K ops/sec on OCTOD
     console.time("cfg");
     const cfg = sut.config(cfgJson);
     for(let i=0; i<10_000; i++){

--- a/packages/azos/test/conf-tests.js
+++ b/packages/azos/test/conf-tests.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as aver from "../aver.js";
 import { $ } from "../linq.js";

--- a/packages/azos/test/linker-tests.js
+++ b/packages/azos/test/linker-tests.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as aver from "azos/aver";
 import {ABSTRACT} from "azos/coreconsts";

--- a/packages/azos/test/linker-tests.js
+++ b/packages/azos/test/linker-tests.js
@@ -5,7 +5,7 @@
 </FILE_LICENSE>*/
 
 //import { describe, it } from "mocha";
-import { defineUnit as describe, defineCase as it } from "../run.js";
+import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as aver from "azos/aver";
 import {ABSTRACT} from "azos/coreconsts";
 import * as conf from "azos/conf";
@@ -32,17 +32,17 @@ class NationWeather extends IWeather{
 
 
 
-describe("Linker", function() {
+unit("Linker", function() {
 
-  describe("ModuleLinker", function() {
+  unit("ModuleLinker", function() {
 
-    it("tinterface-thandler",   function() {
+    cs("tinterface-thandler",   function() {
       const linker = new mod.ModuleLinker();
       aver.areEqual(mod.Module, linker.TInterface);
       aver.areEqual(mod.Module, linker.THandler);
     });
 
-    it("no-name",   function() {
+    cs("no-name",   function() {
       const linker = new mod.ModuleLinker();
       const cfg = conf.config({}).root;
       aver.isTrue(  linker.register(new LocalWeather(apps.NopApplication.instance, cfg))  );
@@ -60,7 +60,7 @@ describe("Linker", function() {
     });
 
 
-    it("with name",   function() {
+    cs("with name",   function() {
       const linker = new mod.ModuleLinker();
       const cfg = conf.config({}).root;
       aver.isTrue(  linker.register(new LocalWeather(apps.NopApplication.instance, cfg), null, "loc")  );
@@ -82,7 +82,7 @@ describe("Linker", function() {
       aver.areEqual("Nationwide weather is fair; 75F: 123", nationWeather.getWeather(123));
     });
 
-    it("concrete type",   function() {
+    cs("concrete type",   function() {
       const linker = new mod.ModuleLinker();
       const cfg = conf.config({}).root;
       aver.isTrue(  linker.register(new LocalWeather(apps.NopApplication.instance, cfg), IWeather)  );
@@ -104,7 +104,7 @@ describe("Linker", function() {
       aver.areEqual("Nationwide weather is fair; 75F: 122", nationWeather.getWeather(122));
     });
 
-    it("concrete type with name",   function() {
+    cs("concrete type with name",   function() {
       const linker = new mod.ModuleLinker();
       const cfg = conf.config({}).root;
       aver.isTrue(  linker.register(new LocalWeather(apps.NopApplication.instance, cfg), IWeather, "loc")  );
@@ -135,7 +135,7 @@ describe("Linker", function() {
 
     });
 
-    it("register-unregister-dump",   function() {
+    cs("register-unregister-dump",   function() {
       const linker = new mod.ModuleLinker();
       const cfg = conf.config({name: null}).root;
 
@@ -239,7 +239,7 @@ describe("Linker", function() {
       aver.areEqual(0, Object.keys(watch).length);
     });
 
-    it("link()",   function() {
+    cs("link()",   function() {
       const linker = new mod.ModuleLinker();
       const cfg = conf.config({}).root;
 

--- a/packages/azos/test/linker-tests2.js
+++ b/packages/azos/test/linker-tests2.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as aver from "azos/aver";
 import { ABSTRACT } from "azos/coreconsts";

--- a/packages/azos/test/linq-tests.js
+++ b/packages/azos/test/linq-tests.js
@@ -4,14 +4,12 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../linq.js";
 import * as aver from "../aver.js";
 import * as types from "../types.js";
 
 unit("LINQ", function() {
-
 
   unit("#iteration", function() {
     cs("root single",   function() {

--- a/packages/azos/test/linq-tests.js
+++ b/packages/azos/test/linq-tests.js
@@ -5,16 +5,16 @@
 </FILE_LICENSE>*/
 
 //import { describe, it } from "mocha";
-import { defineUnit as describe, defineCase as it } from "../run.js";
+import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../linq.js";
 import * as aver from "../aver.js";
 import * as types from "../types.js";
 
-describe("LINQ", function() {
+unit("LINQ", function() {
 
 
-  describe("#iteration", function() {
-    it("root single",   function() {
+  unit("#iteration", function() {
+    cs("root single",   function() {
       let a = [1,2,3];
 
       let q = sut.$(a);
@@ -39,7 +39,7 @@ describe("LINQ", function() {
       aver.areEqual(undefined, entry.value);
     });
 
-    it("toArray single",   function() {
+    cs("toArray single",   function() {
       let a = [1,2,3];
 
       let q = sut.$(a).toArray();
@@ -64,7 +64,7 @@ describe("LINQ", function() {
       aver.areEqual(undefined, entry.value);
     });
 
-    it("toArray multiple",   function() {
+    cs("toArray multiple",   function() {
       let a = [1,2,3];
 
       let q = sut.$(a).toArray();
@@ -100,7 +100,7 @@ describe("LINQ", function() {
       aver.areEqual(undefined, entry2.value);
     });
 
-    it("select single",   function() {
+    cs("select single",   function() {
       let a = [1,2,3];
 
       let q = sut.$(a).select(e => e*10);
@@ -125,7 +125,7 @@ describe("LINQ", function() {
       aver.areEqual(undefined, entry.value);
     });
 
-    it("select multiple",   function() {
+    cs("select multiple",   function() {
       let a = [1,2,3];
 
       let q = sut.$(a).select(e => e*10);
@@ -164,8 +164,8 @@ describe("LINQ", function() {
   });
 
 
-  describe("#select()", function() {
-    it("1",   function() {
+  unit("#select()", function() {
+    cs("1",   function() {
       let a = [1,2,3,4,5];
       let q = sut.$(a).select(e => e*10).toArray();
       aver.areArraysEquivalent([10,20,30,40,50], q);
@@ -173,8 +173,8 @@ describe("LINQ", function() {
 
   });
 
-  describe("#select-where()", function() {
-    it("1",   function() {
+  unit("#select-where()", function() {
+    cs("1",   function() {
       let a = [1,2,3,4,5];
       let q = sut.$(a).select(e => e*10).where(e => e>30).toArray();
       aver.areArraysEquivalent([40,50], q);
@@ -182,9 +182,9 @@ describe("LINQ", function() {
 
   });
 
-  describe("#count()", function() {
+  unit("#count()", function() {
 
-    it("empty",   function() {
+    cs("empty",   function() {
       aver.areEqual( 0, sut.$().count() );
       aver.areEqual( 0, sut.$(undefined).count() );
       aver.areEqual( 0, sut.$(null).count() );
@@ -193,31 +193,31 @@ describe("LINQ", function() {
     });
 
 
-    it("root",   function() {
+    cs("root",   function() {
       let a = [1,2,3,4,5];
       let cnt = sut.$(a).count();
       aver.areEqual( 5, cnt);
     });
 
-    it("select",   function() {
+    cs("select",   function() {
       let a = [1,2,3,4,5];
       let cnt = sut.$(a).select(e => e*10).count();
       aver.areEqual(5, cnt);
     });
 
-    it("select+filter",   function() {
+    cs("select+filter",   function() {
       let a = [1,2,3,4,5];
       let cnt = sut.$(a).select(e => e*10).count(e => e>30);
       aver.areEqual( 2, cnt);
     });
 
-    it("select+where+filter",   function() {
+    cs("select+where+filter",   function() {
       let a = [1,2,3,4,5];
       let cnt = sut.$(a).select(e => e*10).where(e => e>40).count(e => e>30);
       aver.areEqual( 1, cnt);
     });
 
-    it("mixed",   function() {
+    cs("mixed",   function() {
       let a = [1,2,3,4,5];
       aver.areEqual(1, sut.$(a).select(e => e*10).where(e => e>40).count(e => e>30)  );
       aver.areEqual(2, sut.$(a).select(e => e*10).where(e => e>10).count(e => e>30)  );
@@ -229,21 +229,21 @@ describe("LINQ", function() {
   });
 
 
-  describe("#take()", function() {
+  unit("#take()", function() {
 
-    it("empty",   function() {
+    cs("empty",   function() {
       aver.areIterablesEquivalent( [], sut.$().take() );
       aver.areIterablesEquivalent( [], sut.$(undefined).take() );
       aver.areIterablesEquivalent( [], sut.$(null).take() );
     });
 
-    it("basic",   function() {
+    cs("basic",   function() {
       const a = [1,2,3,4,5];
       aver.areIterablesEquivalent( [1,2], sut.$(a).take(2) );
       aver.areIterablesEquivalent( [1,2,3], sut.$(a).take(3) );
     });
 
-    it("chain-take",   function() {
+    cs("chain-take",   function() {
       const a = [1,2,3,4,5];
       aver.areIterablesEquivalent( [12,13,14], sut.$(a).select(e => e+10).where(e=>e>=12).take(3) );
       aver.areIterablesEquivalent( [12,13], sut.$(a).select(e => e+10).take(3).where(e=>e>=12) );
@@ -251,21 +251,21 @@ describe("LINQ", function() {
   });
 
 
-  describe("#skip()", function() {
+  unit("#skip()", function() {
 
-    it("empty",   function() {
+    cs("empty",   function() {
       aver.areIterablesEquivalent( [], sut.$().skip() );
       aver.areIterablesEquivalent( [], sut.$(undefined).skip() );
       aver.areIterablesEquivalent( [], sut.$(null).skip() );
     });
 
-    it("basic",   function() {
+    cs("basic",   function() {
       const a = [1,2,3,4,5];
       aver.areIterablesEquivalent( [3,4,5], sut.$(a).skip(2) );
       aver.areIterablesEquivalent( [], sut.$(a).skip(6) );
     });
 
-    it("chain-skip",   function() {
+    cs("chain-skip",   function() {
       const a = [1,2,3,4,5];
       aver.areIterablesEquivalent( [14,15], sut.$(a).select(e => e+10).where(e=>e>=12).skip(2) );
       aver.areIterablesEquivalent( [15], sut.$(a).select(e => e+10).skip(4).where(e=>e>=12) );
@@ -273,9 +273,9 @@ describe("LINQ", function() {
   });
 
 
-  describe("#any()", function() {
+  unit("#any()", function() {
 
-    it("empty",   function() {
+    cs("empty",   function() {
       aver.isFalse( sut.$().any() );
       aver.isFalse( sut.$().any(undefined) );
       aver.isFalse( sut.$().any(null) );
@@ -289,7 +289,7 @@ describe("LINQ", function() {
       aver.isTrue( sut.$([1,2,3]).any(null) );
     });
 
-    it("basic",   function() {
+    cs("basic",   function() {
       const a = [1,2,3,4,5];
       aver.isTrue( sut.$(a).any() );
       aver.isTrue( sut.$(a).any(e=>e>=5) );
@@ -297,9 +297,9 @@ describe("LINQ", function() {
     });
   });
 
-  describe("#all()", function() {
+  unit("#all()", function() {
 
-    it("empty",   function() {
+    cs("empty",   function() {
       aver.isTrue( sut.$().all() );
       aver.isTrue( sut.$().all(undefined) );
       aver.isTrue( sut.$().all(null) );
@@ -313,7 +313,7 @@ describe("LINQ", function() {
       aver.isTrue( sut.$([1,2,3]).all(null) );
     });
 
-    it("basic",   function() {
+    cs("basic",   function() {
       const a = [1,2,3,4,5];
       aver.isTrue( sut.$(a).all() );
       aver.isFalse( sut.$(a).all(e=>e>3) );
@@ -322,9 +322,9 @@ describe("LINQ", function() {
   });
 
 
-  describe("#isEquivalentTo()", function() {
+  unit("#isEquivalentTo()", function() {
 
-    it("empty",   function() {
+    cs("empty",   function() {
       aver.isFalse( sut.$().isEquivalentTo() );
       aver.isFalse( sut.$().isEquivalentTo(undefined) );
       aver.isFalse( sut.$().isEquivalentTo(null) );
@@ -332,12 +332,12 @@ describe("LINQ", function() {
       aver.isTrue( sut.$([]).isEquivalentTo([]) );
     });
 
-    it("same",   function() {
+    cs("same",   function() {
       let a = sut.$([1,2,3]);
       aver.isTrue( a.isEquivalentTo(a) );
     });
 
-    it("basic",   function() {
+    cs("basic",   function() {
       aver.isTrue( sut.$([1,2,3]).isEquivalentTo([1,2,3]) );
       aver.isFalse( sut.$([1,2,33]).isEquivalentTo([1,2,3]) );
       aver.isFalse( sut.$([1,2,3]).isEquivalentTo([1,2,33]) );
@@ -347,7 +347,7 @@ describe("LINQ", function() {
 
     });
 
-    it("basic wrapped",   function() {
+    cs("basic wrapped",   function() {
       aver.isTrue( sut.$([1,2,3]).isEquivalentTo(   sut.$([1,2,3])  ));
       aver.isFalse( sut.$([1,2,33]).isEquivalentTo( sut.$([1,2,3])  ));
       aver.isFalse( sut.$([1,2,3]).isEquivalentTo(  sut.$([1,2,33]) ));
@@ -356,7 +356,7 @@ describe("LINQ", function() {
       aver.isFalse( sut.$([1,2,3,4]).isEquivalentTo(sut.$([1,2,3])   ));
     });
 
-    it("custom comparer",   function() {
+    cs("custom comparer",   function() {
       aver.isTrue( sut.$([1,2,3]).isEquivalentTo([10,20,30], (a,b) => 10*a === b) );
       aver.isFalse( sut.$([10,20,30]).isEquivalentTo([10,20,30], (a,b) => 10*a === b) );
 
@@ -364,7 +364,7 @@ describe("LINQ", function() {
       aver.isTrue( sut.$([1,2,3]).isEquivalentTo(["1","2","3"], (a,b) => a === types.asInt(b)) );
     });
 
-    it("chained",   function() {
+    cs("chained",   function() {
       const a = sut.$([1,2,3,5,7,9]).where(e => e%2!==0);
       const b = sut.$([1,2,3,4,4,4,4,5,6,7,8,9]).where(e => e%2!==0);
 
@@ -375,9 +375,9 @@ describe("LINQ", function() {
   });
 
 
-  describe("#concat()", function() {
+  unit("#concat()", function() {
 
-    it("empty",   function() {
+    cs("empty",   function() {
 
       const a = sut.$([1,2,3,4]);
 
@@ -386,14 +386,14 @@ describe("LINQ", function() {
       aver.areIterablesEquivalent(a, a.concat(null));
     });
 
-    it("basic",   function() {
+    cs("basic",   function() {
       const a = sut.$([1,2,3,4]);
 
       aver.areIterablesEquivalent([1,2,3,4,-1,1,9], a.concat([-1,1,9]));
       aver.areIterablesEquivalent([1,2,3,4,1,2,3,4], a.concat(a));
     });
 
-    it("chained",   function() {
+    cs("chained",   function() {
       const a = sut.$([1,2,3,4]);
 
       aver.areIterablesEquivalent([3,4,1,2,3,1,2,3,4], a.where(e=>e>=3).concat(a.where(e=>e<4).concat(a)));
@@ -401,9 +401,9 @@ describe("LINQ", function() {
   });
 
 
-  describe("#orderby()", function() {
+  unit("#orderby()", function() {
 
-    it("empty",   function() {
+    cs("empty",   function() {
 
       const a = sut.$([3,2,1,4]);
 
@@ -412,14 +412,14 @@ describe("LINQ", function() {
       aver.areIterablesEquivalent([1,2,3,4], a.orderBy(null));
     });
 
-    it("basic",   function() {
+    cs("basic",   function() {
       const a = sut.$([4,2,1,3]);
 
       aver.areIterablesEquivalent([1,2,3,4], a.orderBy());
       aver.areIterablesEquivalent([4,3,2,1], a.orderBy((a,b) => a>b ? -1 : 1 ));
     });
 
-    it("chained",   function() {
+    cs("chained",   function() {
       const a = sut.$([
         {id: "SRAY", name: "Sugar Ray", age: 123},
         {id: "CJON", name: "Captain John", age: 89},
@@ -434,14 +434,14 @@ describe("LINQ", function() {
   });
 
 
-  describe("#distinct()", function() {
+  unit("#distinct()", function() {
 
-    it("basic",   function() {
+    cs("basic",   function() {
       const a = sut.$([1,2,2,2,2,3,3,4]);
       aver.areIterablesEquivalent([1,2,3,4], a.distinct());
     });
 
-    it("basic + selector",   function() {
+    cs("basic + selector",   function() {
       const a = sut.$([1,2,2,2,2,3,3,4]);
       aver.areIterablesEquivalent([1,3], a.distinct(e => e<3 ? 1 : 2 ));
     });
@@ -453,23 +453,23 @@ describe("LINQ", function() {
       {id: 4, age: 34, name: "Alex"},
       {id: 5, age: 35, name: "Alex"}]);
 
-    it("objects + selector",   function() {
+    cs("objects + selector",   function() {
       aver.areIterablesEquivalent([10,12,34,35], a.distinct(e => e.age).select(e => e.age));
       aver.areIterablesEquivalent(["Alex","Doris","Alex","Alex"], a.distinct(e => e.age).select(e => e.name));
       aver.areIterablesEquivalent([10,12,10], a.distinct(e => e.name).select(e => e.age));
       aver.areIterablesEquivalent([1,2,3], a.distinct(e => e.name).select(e => e.id));
     });
 
-    it("objects + selector + count",   function() {
+    cs("objects + selector + count",   function() {
       aver.areEqual( 4, a.distinct(e => e.age).count() );
       aver.areEqual( 3, a.distinct(e => e.name).count() );
     });
   });
 
 
-  describe("#firstOrDefault()", function() {
+  unit("#firstOrDefault()", function() {
 
-    it("empty+basic",   function() {
+    cs("empty+basic",   function() {
 
       const a = sut.$([3,2,1,4]);
 
@@ -482,7 +482,7 @@ describe("LINQ", function() {
       aver.areEqual(3, match.value);
     });
 
-    it("with predicate",   function() {
+    cs("with predicate",   function() {
       const a = sut.$([3,2,1,4]);
 
       let match = a.firstOrDefault(e => e>3);
@@ -494,7 +494,7 @@ describe("LINQ", function() {
       aver.isUndefined(match.value);
     });
 
-    it("chained",   function() {
+    cs("chained",   function() {
       const a = sut.$([1,2,3,4,5,6,7,8,9,0]);
 
       aver.areEqual( 22, a.where(e => e> 1).select(e => (e*10)+e).firstOrDefault().value);
@@ -502,9 +502,9 @@ describe("LINQ", function() {
     });
   });
 
-  describe("#first()", function() {
+  unit("#first()", function() {
 
-    it("basic",   function() {
+    cs("basic",   function() {
 
       const a = sut.$([3,2,1,4]);
       aver.areEqual(3,a.first());
@@ -515,7 +515,7 @@ describe("LINQ", function() {
 
     });
 
-    it("empty sequence",   function() {
+    cs("empty sequence",   function() {
       const a = sut.$();
       aver.throws( function(){
         a.first();

--- a/packages/azos/test/localization-tests.js
+++ b/packages/azos/test/localization-tests.js
@@ -5,22 +5,22 @@
 </FILE_LICENSE>*/
 
 //import { describe, it } from "mocha";
-import { defineUnit as describe, defineCase as it } from "../run.js";
+import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../localization.js";
 import * as aver from "../aver.js";
 import { GLOBALS } from "../coreconsts.js";
 import { TimeZone } from "../time.js";
 import { config } from "../conf.js";
 
-describe("Localization", function() {
+unit("Localization", function() {
 
-  describe("#Localizer", function() {
+  unit("#Localizer", function() {
 
     const dloc = GLOBALS.DEFAULT_INVARIANT;//Default Localizer
 
 
-    describe("#getCurrencySymbols()", function() {
-      it("returns object", function(){
+    unit("#getCurrencySymbols()", function() {
+      cs("returns object", function(){
         let got = dloc.getCurrencySymbols(sut.CULTURE_INVARIANT);
         console.log( got );
         aver.areEqual("$", got.sym);
@@ -29,24 +29,24 @@ describe("Localization", function() {
       });
     });
 
-    describe("#getPrimaryLanguageIso()", function() {
-      it("returns ENG", function(){
+    unit("#getPrimaryLanguageIso()", function() {
+      cs("returns ENG", function(){
         let got = dloc.getPrimaryLanguageIso(sut.CULTURE_INVARIANT);
         console.log( got );
         aver.areEqual(sut.ISO_LANG_ENG, got);
       });
     });
 
-    describe("#getLanguageIsos()", function() {
-      it("returns ENG", function(){
+    unit("#getLanguageIsos()", function() {
+      cs("returns ENG", function(){
         let got = dloc.getLanguageIsos(sut.CULTURE_INVARIANT);
         aver.isArray(got);
         aver.areEqual(sut.ISO_LANG_ENG, got[0]);
       });
     });
 
-    describe("#getStringLocalizationIsos()", function() {
-      it("returns ENG", function(){
+    unit("#getStringLocalizationIsos()", function() {
+      cs("returns ENG", function(){
         let got = dloc.getStringLocalizationIsos();
         aver.isArray(got);
         aver.areEqual(5, got.length);
@@ -55,113 +55,113 @@ describe("Localization", function() {
       });
     });
 
-    describe("#localizeString()", function() {
-      it("passthrough", function(){   aver.areEqual("doesnotexist", dloc.localizeString("doesnotexist", sut.ISO_LANG_ENG));   });
-      it("yes",  function(){   aver.areEqual("да",   dloc.localizeString("yes", sut.ISO_LANG_RUS));   });
-      it("no",   function(){   aver.areEqual("нет",  dloc.localizeString("no", sut.ISO_LANG_RUS));    });
-      it("abra", function(){   aver.areEqual("abra", dloc.localizeString("abra", sut.ISO_LANG_RUS));  });
+    unit("#localizeString()", function() {
+      cs("passthrough", function(){   aver.areEqual("doesnotexist", dloc.localizeString("doesnotexist", sut.ISO_LANG_ENG));   });
+      cs("yes",  function(){   aver.areEqual("да",   dloc.localizeString("yes", sut.ISO_LANG_RUS));   });
+      cs("no",   function(){   aver.areEqual("нет",  dloc.localizeString("no", sut.ISO_LANG_RUS));    });
+      cs("abra", function(){   aver.areEqual("abra", dloc.localizeString("abra", sut.ISO_LANG_RUS));  });
 
-      it("yes",  function(){   aver.areEqual("ja",   dloc.localizeString("yes", sut.ISO_LANG_DEU));   });
-      it("no",   function(){   aver.areEqual("nein", dloc.localizeString("no", sut.ISO_LANG_DEU));    });
-      it("abra", function(){   aver.areEqual("abra", dloc.localizeString("abra", sut.ISO_LANG_DEU));  });
+      cs("yes",  function(){   aver.areEqual("ja",   dloc.localizeString("yes", sut.ISO_LANG_DEU));   });
+      cs("no",   function(){   aver.areEqual("nein", dloc.localizeString("no", sut.ISO_LANG_DEU));    });
+      cs("abra", function(){   aver.areEqual("abra", dloc.localizeString("abra", sut.ISO_LANG_DEU));  });
 
-      it("yes in schema",  function(){   aver.areEqual("так",   dloc.localizeString("yes", sut.ISO_LANG_RUS, sut.ANY_FIELD, "tezt"));   });
-      it("no in schema",   function(){   aver.areEqual("неа",   dloc.localizeString("no", sut.ISO_LANG_RUS, sut.ANY_FIELD, "tezt"));   });
-      it("yes in n/a filed n/a schema",  function(){   aver.areEqual("да",   dloc.localizeString("yes", sut.ISO_LANG_RUS, "fieldX", "schemaX"));   });
-      it("yes in anyf/anys",  function(){   aver.areEqual("да",   dloc.localizeString("yes", sut.ISO_LANG_RUS, sut.ANY_FIELD, sut.ANY_SCHEMA));   });
+      cs("yes in schema",  function(){   aver.areEqual("так",   dloc.localizeString("yes", sut.ISO_LANG_RUS, sut.ANY_FIELD, "tezt"));   });
+      cs("no in schema",   function(){   aver.areEqual("неа",   dloc.localizeString("no", sut.ISO_LANG_RUS, sut.ANY_FIELD, "tezt"));   });
+      cs("yes in n/a filed n/a schema",  function(){   aver.areEqual("да",   dloc.localizeString("yes", sut.ISO_LANG_RUS, "fieldX", "schemaX"));   });
+      cs("yes in anyf/anys",  function(){   aver.areEqual("да",   dloc.localizeString("yes", sut.ISO_LANG_RUS, sut.ANY_FIELD, sut.ANY_SCHEMA));   });
     });
 
 
-    describe("#formatDateTime()", function() {
+    unit("#formatDateTime()", function() {
 
       const dt = new Date(Date.UTC(2017, 5, 12,  15, 43, 19, 89));// UTC 12/june/2017 = Monday
 
-      it("arg0s", function(){
+      cs("arg0s", function(){
         let got = dloc.formatDateTime(dt);
         console.log( got );
         aver.areEqual("06/12/2017", got);
       });
 
-      it("LONG_WEEK_DATE", function(){
+      cs("LONG_WEEK_DATE", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.LONG_WEEK_DATE});
         console.log( got );
         aver.areEqual("Monday, 12 June 2017", got);
       });
 
-      it("SHORT_WEEK_DATE", function(){
+      cs("SHORT_WEEK_DATE", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.SHORT_WEEK_DATE});
         console.log( got );
         aver.areEqual("Mon, 12 Jun 2017", got);
       });
 
-      it("LONG_DATE", function(){
+      cs("LONG_DATE", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.LONG_DATE});
         console.log( got );
         aver.areEqual("12 June 2017", got);
       });
 
-      it("SHORT_DATE", function(){
+      cs("SHORT_DATE", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.SHORT_DATE});
         console.log( got );
         aver.areEqual("12 Jun 2017", got);
       });
 
-      it("NUM_DATE", function(){
+      cs("NUM_DATE", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.NUM_DATE});
         console.log( got );
         aver.areEqual("06/12/2017", got);
       });
 
-      it("LONG_MONTH", function(){
+      cs("LONG_MONTH", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.LONG_MONTH});
         console.log( got );
         aver.areEqual("June 2017", got);
       });
 
-      it("SHORT_MONTH", function(){
+      cs("SHORT_MONTH", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.SHORT_MONTH});
         console.log( got );
         aver.areEqual("Jun 2017", got);
       });
 
-      it("NUM_MONTH", function(){
+      cs("NUM_MONTH", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.NUM_MONTH});
         console.log( got );
         aver.areEqual("06/2017", got);
       });
 
-      it("LONG_DAY_MONTH", function(){
+      cs("LONG_DAY_MONTH", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.LONG_DAY_MONTH});
         console.log( got );
         aver.areEqual("12 June", got);
       });
 
-      it("SHORT_DAY_MONTH", function(){
+      cs("SHORT_DAY_MONTH", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.SHORT_DAY_MONTH});
         console.log( got );
         aver.areEqual("12 Jun", got);
       });
 
 
-      it("LONG_WEEK_DATE+HM", function(){
+      cs("LONG_WEEK_DATE+HM", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.LONG_WEEK_DATE, tmDetails: sut.TIME_DETAILS.HM});
         console.log( got );
         aver.areEqual("Monday, 12 June 2017 15:43", got);
       });
 
-      it("LONG_WEEK_DATE+HMS", function(){
+      cs("LONG_WEEK_DATE+HMS", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.LONG_WEEK_DATE, tmDetails: sut.TIME_DETAILS.HMS});
         console.log( got );
         aver.areEqual("Monday, 12 June 2017 15:43:19", got);
       });
 
-      it("LONG_WEEK_DATE+HMSM", function(){
+      cs("LONG_WEEK_DATE+HMSM", function(){
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.LONG_WEEK_DATE, tmDetails: sut.TIME_DETAILS.HMSM});
         console.log( got );
         aver.areEqual("Monday, 12 June 2017 15:43:19:089", got);
       });
 
-      it("LONG_WEEK_DATE+HMSM in TIme zone", function(){
+      cs("LONG_WEEK_DATE+HMSM in TIme zone", function(){
         const tzXXX = new TimeZone(config({name: "xxx",   description: "XXX Fake timezone", iana: "xxx", windows: "xxx", baseOffsetMs: -1 * 60 * 60 * 1000}).root);
         let got = dloc.formatDateTime({dt: dt, dtFormat: sut.DATE_FORMAT.LONG_WEEK_DATE, tmDetails: sut.TIME_DETAILS.HMSM, timeZone: tzXXX});
         console.log( got );
@@ -172,58 +172,58 @@ describe("Localization", function() {
     });
 
 
-    describe("#formatCurrency()", function() {
-      it("fun args1", function(){
+    unit("#formatCurrency()", function() {
+      cs("fun args1", function(){
         let got = dloc.formatCurrency(9123750000, "usd");
         aver.areEqual("$9,123,750,000.00", got);
       });
 
-      it("fun args2", function(){
+      cs("fun args2", function(){
         let got = dloc.formatCurrency(-9123750000, "usd");
         aver.areEqual("-$9,123,750,000.00", got);
       });
 
-      it("obj1", function(){
+      cs("obj1", function(){
         let got = dloc.formatCurrency({amt: -9123750000, iso: "usd"});
         aver.areEqual("-$9,123,750,000.00", got);
       });
 
-      it("obj1 - no decimals", function(){
+      cs("obj1 - no decimals", function(){
         let got = dloc.formatCurrency({amt: -9123750000, iso: "usd", precision: 0});
         aver.areEqual("-$9,123,750,000", got);
       });
 
-      it("obj2", function(){
+      cs("obj2", function(){
         let got = dloc.formatCurrency({amt: -3123750000.123456, iso: "usd", thousands: false, precision: 4});
         aver.areEqual("-$3123750000.1234", got);
       });
 
-      it("obj3", function(){
+      cs("obj3", function(){
         let got = dloc.formatCurrency({amt: -3123750000.123456, iso: "usd", thousands: false, precision: 2, sign: false});
         aver.areEqual("($3123750000.12)", got);
       });
 
-      it("obj4", function(){
+      cs("obj4", function(){
         let got = dloc.formatCurrency({amt: -3123750000.123456, iso: "usd", thousands: false, precision: 2, sign: false, symbol: false});
         aver.areEqual("(3123750000.12)", got);
       });
 
-      it("obj5", function(){
+      cs("obj5", function(){
         let got = dloc.formatCurrency({amt: -3123750000.123456, iso: "usd", thousands: true, precision: 2, sign: true, symbol: false});
         aver.areEqual("-3,123,750,000.12", got);
       });
 
-      it("large amount", function(){
+      cs("large amount", function(){
         let got = dloc.formatCurrency({amt: -25978123750321.18, iso: "usd", thousands: true, precision: 2, sign: true, symbol: true});
         aver.areEqual("-$25,978,123,750,321.18", got);
       });
 
-      it("large amount.00", function(){
+      cs("large amount.00", function(){
         let got = dloc.formatCurrency({amt: -125978123750321.00, iso: "usd", thousands: true, precision: 2, sign: true, symbol: true});
         aver.areEqual("-$125,978,123,750,321.00", got);
       });
 
-      it("large amount - no decimals", function(){
+      cs("large amount - no decimals", function(){
         let got = dloc.formatCurrency({amt: -25978123750321.18, iso: "usd", thousands: true, precision: 0, sign: true, symbol: true});
         aver.areEqual("-$25,978,123,750,321", got);
       });

--- a/packages/azos/test/localization-tests.js
+++ b/packages/azos/test/localization-tests.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../localization.js";
 import * as aver from "../aver.js";

--- a/packages/azos/test/router-tests.js
+++ b/packages/azos/test/router-tests.js
@@ -4,7 +4,7 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-import { defineUnit as unit, defineCase as cse } from "../run.js";
+import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as aver from "azos/aver";
 import { config, ConfigNode } from "azos/conf";
 import * as apps from "azos/application";
@@ -15,7 +15,7 @@ unit("Router", function() {
 
   unit("Integration", function(){
 
-    cse("base-functionality-01", function(){
+    cs("base-functionality-01", function(){
 
       const cfg = config({
         errorPath: "error",

--- a/packages/azos/test/security-tests.js
+++ b/packages/azos/test/security-tests.js
@@ -4,13 +4,13 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-import { defineUnit as describe, defineCase as it } from "../run.js";
+import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../security.js";
 import * as aver from "../aver.js";
 
-describe("Security", function() {
-  describe("#parseJwtToken()", function() {
-    it("parseSample1", function(){
+unit("Security", function() {
+  unit("#parseJwtToken()", function() {
+    cs("parseSample1", function(){
       /*
       {
   "sub": "1234567890",

--- a/packages/azos/test/strings-tests.js
+++ b/packages/azos/test/strings-tests.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../strings.js";
 import * as aver from "../aver.js";

--- a/packages/azos/test/time-tests.js
+++ b/packages/azos/test/time-tests.js
@@ -82,10 +82,10 @@ unit("Time", function () {
         aver.isOf(utc, TimeZone, "UTC is a TimeZone");//even when it is not declared, it is always present
 
         const tz1 = localizer.getTimeZone("t1");
-        aver.isOf(tz1, TeztTimeZone, "UTC is a TimeZone");
+        aver.isOf(tz1, TeztTimeZone, "tz1 is a TimeZone");
 
         const tz2 = localizer.getTimeZone("t2");
-        aver.isOf(tz2, TeztTimeZone, "UTC is a TimeZone");
+        aver.isOf(tz2, TeztTimeZone, "tz2 is a TimeZone");
 
         const allZones = localizer.getAllTimeZones();
         aver.isArray(allZones, "getAllZones");

--- a/packages/azos/test/types-tests.js
+++ b/packages/azos/test/types-tests.js
@@ -5,53 +5,53 @@
 </FILE_LICENSE>*/
 
 //import { describe, it } from "mocha";
-import { defineUnit as describe, defineCase as it } from "../run.js";
+import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../types.js";
 import * as strings from "../strings.js";
 import * as aver from "../aver.js";
 
-describe("Types", function() {
+unit("Types", function() {
 
-  describe("#isAssigned()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isAssigned()           );});
-    it("false for undefined", function() { aver.isFalse( sut.isAssigned(undefined)  );});
-    it("false for null",      function() { aver.isFalse( sut.isAssigned(null)       );});
+  unit("#isAssigned()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isAssigned()           );});
+    cs("false for undefined", function() { aver.isFalse( sut.isAssigned(undefined)  );});
+    cs("false for null",      function() { aver.isFalse( sut.isAssigned(null)       );});
 
-    it("true for ''",    function() { aver.isTrue( sut.isAssigned("")       );});
-    it("true for 'abc'", function() { aver.isTrue( sut.isAssigned("abc")    );});
-    it("true for []",    function() { aver.isTrue( sut.isAssigned([])    );});
-    it("true for {}",    function() { aver.isTrue( sut.isAssigned({})    );});
-    it("true for true",  function() { aver.isTrue( sut.isAssigned(true)    );});
-    it("true for false", function() { aver.isTrue( sut.isAssigned(false)    );});
-    it("true for 123",   function() { aver.isTrue( sut.isAssigned(123)    );});
-    it("true for Date",  function() { aver.isTrue( sut.isAssigned(new Date(1980,1, 21))    );});
+    cs("true for ''",    function() { aver.isTrue( sut.isAssigned("")       );});
+    cs("true for 'abc'", function() { aver.isTrue( sut.isAssigned("abc")    );});
+    cs("true for []",    function() { aver.isTrue( sut.isAssigned([])    );});
+    cs("true for {}",    function() { aver.isTrue( sut.isAssigned({})    );});
+    cs("true for true",  function() { aver.isTrue( sut.isAssigned(true)    );});
+    cs("true for false", function() { aver.isTrue( sut.isAssigned(false)    );});
+    cs("true for 123",   function() { aver.isTrue( sut.isAssigned(123)    );});
+    cs("true for Date",  function() { aver.isTrue( sut.isAssigned(new Date(1980,1, 21))    );});
   });
 
-  describe("#hown()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.hown()  );});
-    it("false for undefined", function() { aver.isFalse( sut.hown(undefined)  );});
-    it("false for null",      function() { aver.isFalse( sut.hown(null)       );});
+  unit("#hown()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.hown()  );});
+    cs("false for undefined", function() { aver.isFalse( sut.hown(undefined)  );});
+    cs("false for null",      function() { aver.isFalse( sut.hown(null)       );});
 
-    it("{}",        function() { aver.isFalse( sut.hown({})  );});
-    it("{}, null",  function() { aver.isFalse( sut.hown({}, null)  );});
-    it("null, 'a'", function() { aver.isFalse( sut.hown(null, "a")  );});
-    it("{}, 'a'",   function() { aver.isFalse( sut.hown({}, "a")  );});
+    cs("{}",        function() { aver.isFalse( sut.hown({})  );});
+    cs("{}, null",  function() { aver.isFalse( sut.hown({}, null)  );});
+    cs("null, 'a'", function() { aver.isFalse( sut.hown(null, "a")  );});
+    cs("{}, 'a'",   function() { aver.isFalse( sut.hown({}, "a")  );});
 
-    it("{a: undefined}, 'a'", function() { aver.isTrue( sut.hown({a: undefined}, "a")  );});
+    cs("{a: undefined}, 'a'", function() { aver.isTrue( sut.hown({a: undefined}, "a")  );});
 
-    it("{[symbol1]: 1}, symbol1", function() {
+    cs("{[symbol1]: 1}, symbol1", function() {
       const s1 = Symbol("1");
       aver.isTrue( sut.hown({[s1]: 1}, s1)  );
     });
 
-    it("{[symbol2]: 1}, symbol1", function() {
+    cs("{[symbol2]: 1}, symbol1", function() {
       const s1 = Symbol("111111");
       const s2 = Symbol("222222");
       aver.isTrue( sut.hown({[s1]: 1}, s1)  );
       aver.isFalse( sut.hown({[s1]: 1}, s2)  );
     });
 
-    it("inherit", function() {
+    cs("inherit", function() {
       function MyClass() {this.A = 1;}
       MyClass.prototype = {B: 2};
 
@@ -63,17 +63,17 @@ describe("Types", function() {
     });
   });
 
-  describe("#allObjectValues()", function() {
-    it("()",          () => aver.areArraysEquivalent([], sut.allObjectValues()) );
-    it("(undefined)", () => aver.areArraysEquivalent([], sut.allObjectValues(undefined)) );
-    it("(null)",      () => aver.areArraysEquivalent([], sut.allObjectValues(null)) );
+  unit("#allObjectValues()", function() {
+    cs("()",          () => aver.areArraysEquivalent([], sut.allObjectValues()) );
+    cs("(undefined)", () => aver.areArraysEquivalent([], sut.allObjectValues(undefined)) );
+    cs("(null)",      () => aver.areArraysEquivalent([], sut.allObjectValues(null)) );
 
-    it("flat",    function(){
+    cs("flat",    function(){
       let o = {a: 1, b: true};
       aver.areArraysEquivalent([1, true], sut.allObjectValues(o));
     });
 
-    it("with proto",  function(){
+    cs("with proto",  function(){
       function A(){ this.a = 1; this.b = true; this.z = "hello";}
       A.prototype.c = 123;
       let o = new A();
@@ -86,8 +86,8 @@ describe("Types", function() {
 
 
 
-  describe("#arrayDelete()", function() {
-    it("deletes int",   function() {
+  unit("#arrayDelete()", function() {
+    cs("deletes int",   function() {
       let a = [1,2,3];
       aver.isTrue( sut.arrayDelete(a, 2)  );
       aver.areEqual(2, a.length );
@@ -95,7 +95,7 @@ describe("Types", function() {
       aver.areEqual(3, a[1] );
     });
 
-    it("deletes int once",   function() {
+    cs("deletes int once",   function() {
       let a = [1,2,3,2];
       aver.isTrue( sut.arrayDelete(a, 2)  );
       aver.areEqual(3, a.length );
@@ -104,7 +104,7 @@ describe("Types", function() {
       aver.areEqual(2, a[2] );
     });
 
-    it("deletes undefined",   function() {
+    cs("deletes undefined",   function() {
       let a = [1,2,undefined];
       aver.isTrue( sut.arrayDelete(a, undefined)  );
       aver.areEqual(2, a.length );
@@ -112,7 +112,7 @@ describe("Types", function() {
       aver.areEqual(2, a[1] );
     });
 
-    it("does not delete absent",   function() {
+    cs("does not delete absent",   function() {
       let a = [1, 2, 3];
       aver.isFalse( sut.arrayDelete(a, 5)  );
       aver.areEqual(3, a.length );
@@ -121,7 +121,7 @@ describe("Types", function() {
       aver.areEqual(3, a[2] );
     });
 
-    it("deletes objects",   function() {
+    cs("deletes objects",   function() {
       let o = {c: 3};
       let a = [{a: 1}, {b: 2}, o];
       aver.isTrue( sut.arrayDelete(a, o)  );
@@ -132,8 +132,8 @@ describe("Types", function() {
   });
 
 
-  describe("#arrayCopy()", function() {
-    it("copies",   function() {
+  unit("#arrayCopy()", function() {
+    cs("copies",   function() {
       let a = [1,2,3];
       let b = sut.arrayCopy(a);
 
@@ -145,8 +145,8 @@ describe("Types", function() {
     });
   });
 
-  describe("#arrayClear()", function() {
-    it("clears",   function() {
+  unit("#arrayClear()", function() {
+    cs("clears",   function() {
       const a = [1,2,3];
       let b = sut.arrayClear(a);
       aver.areEqual(a, b );
@@ -154,138 +154,138 @@ describe("Types", function() {
     });
   });
 
-  describe("#isString()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isString()           );});
-    it("false for undefined", function() { aver.isFalse( sut.isString(undefined)  );});
-    it("false for null",      function() { aver.isFalse( sut.isString(null)       );});
+  unit("#isString()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isString()           );});
+    cs("false for undefined", function() { aver.isFalse( sut.isString(undefined)  );});
+    cs("false for null",      function() { aver.isFalse( sut.isString(null)       );});
 
-    it("false for true",      function() { aver.isFalse( sut.isString(true) );});
-    it("false for 1",      function() { aver.isFalse( sut.isString(1)       );});
-    it("false for []",      function() { aver.isFalse( sut.isString([])     );});
-    it("false for {}",      function() { aver.isFalse( sut.isString({})     );});
+    cs("false for true",      function() { aver.isFalse( sut.isString(true) );});
+    cs("false for 1",      function() { aver.isFalse( sut.isString(1)       );});
+    cs("false for []",      function() { aver.isFalse( sut.isString([])     );});
+    cs("false for {}",      function() { aver.isFalse( sut.isString({})     );});
 
-    it("true for ''",       function() { aver.isTrue( sut.isString("")       );});
-    it("true for 'abc'",   function() { aver.isTrue( sut.isString("abc")    );});
+    cs("true for ''",       function() { aver.isTrue( sut.isString("")       );});
+    cs("true for 'abc'",   function() { aver.isTrue( sut.isString("abc")    );});
 
-    it("true for new String('abc')",   function() { aver.isTrue( sut.isString( new String("abc") )) ;});
+    cs("true for new String('abc')",   function() { aver.isTrue( sut.isString( new String("abc") )) ;});
   });
 
 
-  describe("#isDate()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isDate()           );});
-    it("false for undefined", function() { aver.isFalse( sut.isDate(undefined)  );});
-    it("false for null",      function() { aver.isFalse( sut.isDate(null)       );});
+  unit("#isDate()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isDate()           );});
+    cs("false for undefined", function() { aver.isFalse( sut.isDate(undefined)  );});
+    cs("false for null",      function() { aver.isFalse( sut.isDate(null)       );});
 
-    it("true for date",      function() { aver.isTrue( sut.isDate( new Date("December 25, 2014")) );});
-    it("true for date(now)", function() { aver.isTrue( sut.isDate( new Date( Date.now() )) );});
+    cs("true for date",      function() { aver.isTrue( sut.isDate( new Date("December 25, 2014")) );});
+    cs("true for date(now)", function() { aver.isTrue( sut.isDate( new Date( Date.now() )) );});
   });
 
 
-  describe("#isNumber()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isNumber()           );});
-    it("false for undefined", function() { aver.isFalse( sut.isNumber(undefined)  );});
-    it("false for null",      function() { aver.isFalse( sut.isNumber(null)       );});
+  unit("#isNumber()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isNumber()           );});
+    cs("false for undefined", function() { aver.isFalse( sut.isNumber(undefined)  );});
+    cs("false for null",      function() { aver.isFalse( sut.isNumber(null)       );});
 
-    it("false for {}",      function() { aver.isFalse( sut.isNumber({})       );});
-    it("false for true",      function() { aver.isFalse( sut.isNumber(true)   );});
-    it("false for 'abc'",      function() { aver.isFalse( sut.isNumber("abc") );});
-    it("false for '2'",  function() { aver.isFalse( sut.isNumber( "2" )); });
+    cs("false for {}",      function() { aver.isFalse( sut.isNumber({})       );});
+    cs("false for true",      function() { aver.isFalse( sut.isNumber(true)   );});
+    cs("false for 'abc'",      function() { aver.isFalse( sut.isNumber("abc") );});
+    cs("false for '2'",  function() { aver.isFalse( sut.isNumber( "2" )); });
 
 
-    it("true for 2",    function() { aver.isTrue( sut.isNumber( 2 )); });
-    it("true for -123.1232",    function() { aver.isTrue( sut.isNumber( -123.1232 )); });
+    cs("true for 2",    function() { aver.isTrue( sut.isNumber( 2 )); });
+    cs("true for -123.1232",    function() { aver.isTrue( sut.isNumber( -123.1232 )); });
 
-    it("true for new Number(-123.1232)",    function() { aver.isTrue( sut.isNumber( new Number(-123.1232) )); });
+    cs("true for new Number(-123.1232)",    function() { aver.isTrue( sut.isNumber( new Number(-123.1232) )); });
   });
 
 
-  describe("#isBool()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isBool()           );});
-    it("false for undefined", function() { aver.isFalse( sut.isBool(undefined)  );});
-    it("false for null",      function() { aver.isFalse( sut.isBool(null)       );});
+  unit("#isBool()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isBool()           );});
+    cs("false for undefined", function() { aver.isFalse( sut.isBool(undefined)  );});
+    cs("false for null",      function() { aver.isFalse( sut.isBool(null)       );});
 
-    it("false for {}",      function() { aver.isFalse( sut.isBool({})       );});
-    it("false for 'abc'",   function() { aver.isFalse( sut.isBool("abc") );});
-    it("false for 1",       function() { aver.isFalse( sut.isBool( 1 )); });
-    it("false for '1'",     function() { aver.isFalse( sut.isBool( "1" )); });
+    cs("false for {}",      function() { aver.isFalse( sut.isBool({})       );});
+    cs("false for 'abc'",   function() { aver.isFalse( sut.isBool("abc") );});
+    cs("false for 1",       function() { aver.isFalse( sut.isBool( 1 )); });
+    cs("false for '1'",     function() { aver.isFalse( sut.isBool( "1" )); });
 
 
-    it("true for true",    function() { aver.isTrue( sut.isBool( true )); });
-    it("true for false",    function() { aver.isTrue( sut.isBool( false )); });
+    cs("true for true",    function() { aver.isTrue( sut.isBool( true )); });
+    cs("true for false",    function() { aver.isTrue( sut.isBool( false )); });
 
-    it("true for new Boolean()",    function() { aver.isTrue( sut.isBool( new Boolean(true) )); });
+    cs("true for new Boolean()",    function() { aver.isTrue( sut.isBool( new Boolean(true) )); });
   });
 
-  describe("#isSymbol()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isSymbol()           );});
-    it("false for undefined", function() { aver.isFalse( sut.isSymbol(undefined)  );});
-    it("false for null",      function() { aver.isFalse( sut.isSymbol(null)       );});
+  unit("#isSymbol()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isSymbol()           );});
+    cs("false for undefined", function() { aver.isFalse( sut.isSymbol(undefined)  );});
+    cs("false for null",      function() { aver.isFalse( sut.isSymbol(null)       );});
 
-    it("false for {}",      function() { aver.isFalse( sut.isSymbol({})       );});
-    it("false for 'abc'",   function() { aver.isFalse( sut.isSymbol("abc") );});
-    it("false for 1",       function() { aver.isFalse( sut.isSymbol( 1 )); });
-    it("false for '1'",     function() { aver.isFalse( sut.isSymbol( "1" )); });
+    cs("false for {}",      function() { aver.isFalse( sut.isSymbol({})       );});
+    cs("false for 'abc'",   function() { aver.isFalse( sut.isSymbol("abc") );});
+    cs("false for 1",       function() { aver.isFalse( sut.isSymbol( 1 )); });
+    cs("false for '1'",     function() { aver.isFalse( sut.isSymbol( "1" )); });
 
 
-    it("true for Sym 123",    function() { aver.isTrue( sut.isSymbol( Symbol(123) )); });
-    it("true for Sym xyz",    function() { aver.isTrue( sut.isSymbol( Symbol("xyz"))); });
+    cs("true for Sym 123",    function() { aver.isTrue( sut.isSymbol( Symbol(123) )); });
+    cs("true for Sym xyz",    function() { aver.isTrue( sut.isSymbol( Symbol("xyz"))); });
   });
 
 
-  describe("#isArray()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isArray()          );});
-    it("false for undefined", function() { aver.isFalse( sut.isArray(undefined) );});
-    it("false for null",      function() { aver.isFalse( sut.isArray(null)      );});
-    it("false for true",      function() { aver.isFalse( sut.isArray(true)      );});
-    it("false for int",       function() { aver.isFalse( sut.isArray(123)       );});
-    it("false for string",    function() { aver.isFalse( sut.isArray("zaza")    );});
-    it("false for {}",        function() { aver.isFalse( sut.isArray({})        );});
+  unit("#isArray()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isArray()          );});
+    cs("false for undefined", function() { aver.isFalse( sut.isArray(undefined) );});
+    cs("false for null",      function() { aver.isFalse( sut.isArray(null)      );});
+    cs("false for true",      function() { aver.isFalse( sut.isArray(true)      );});
+    cs("false for int",       function() { aver.isFalse( sut.isArray(123)       );});
+    cs("false for string",    function() { aver.isFalse( sut.isArray("zaza")    );});
+    cs("false for {}",        function() { aver.isFalse( sut.isArray({})        );});
 
-    it("false for function{}",        function() { aver.isFalse( sut.isArray(function(){}) );});
+    cs("false for function{}",        function() { aver.isFalse( sut.isArray(function(){}) );});
 
-    it("true for []",            function() { aver.isTrue( sut.isArray([])           );});
-    it("true for [null, null]",  function() { aver.isTrue( sut.isArray([null, null]) );});
-    it("true for [1,2,3]",       function() { aver.isTrue( sut.isArray([1,2,3])      );});
+    cs("true for []",            function() { aver.isTrue( sut.isArray([])           );});
+    cs("true for [null, null]",  function() { aver.isTrue( sut.isArray([null, null]) );});
+    cs("true for [1,2,3]",       function() { aver.isTrue( sut.isArray([1,2,3])      );});
 
-    it("true for new Array()",       function() { aver.isTrue( sut.isArray( new Array()) );});
+    cs("true for new Array()",       function() { aver.isTrue( sut.isArray( new Array()) );});
   });
 
-  describe("#isObject()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isObject()          );});
-    it("false for undefined", function() { aver.isFalse( sut.isObject(undefined) );});
-    it("false for null",      function() { aver.isFalse( sut.isObject(null)      );});
-    it("false for true",      function() { aver.isFalse( sut.isObject(true)      );});
-    it("false for int",       function() { aver.isFalse( sut.isObject(123)       );});
-    it("false for string",    function() { aver.isFalse( sut.isObject("zaza")    );});
-    it("false for []",        function() { aver.isFalse( sut.isObject([])    );});
+  unit("#isObject()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isObject()          );});
+    cs("false for undefined", function() { aver.isFalse( sut.isObject(undefined) );});
+    cs("false for null",      function() { aver.isFalse( sut.isObject(null)      );});
+    cs("false for true",      function() { aver.isFalse( sut.isObject(true)      );});
+    cs("false for int",       function() { aver.isFalse( sut.isObject(123)       );});
+    cs("false for string",    function() { aver.isFalse( sut.isObject("zaza")    );});
+    cs("false for []",        function() { aver.isFalse( sut.isObject([])    );});
 
-    it("false for function{}",        function() { aver.isFalse( sut.isObject(function(){}) );});
+    cs("false for function{}",        function() { aver.isFalse( sut.isObject(function(){}) );});
 
-    it("true for {}",        function() { aver.isTrue( sut.isObject({})        );});
-    it("true for {a:1...}",  function() { aver.isTrue( sut.isObject({a: 2, b: 3}) );});
+    cs("true for {}",        function() { aver.isTrue( sut.isObject({})        );});
+    cs("true for {a:1...}",  function() { aver.isTrue( sut.isObject({a: 2, b: 3}) );});
 
     function Car(){ this.a=1; }
 
-    it("true for new Car()",  function() { aver.isTrue( sut.isObject(new Car()) );});
+    cs("true for new Car()",  function() { aver.isTrue( sut.isObject(new Car()) );});
   });
 
-  describe("#isFunction()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isFunction()          );});
-    it("false for undefined", function() { aver.isFalse( sut.isFunction(undefined) );});
-    it("false for null",      function() { aver.isFalse( sut.isFunction(null)      );});
-    it("false for true",      function() { aver.isFalse( sut.isFunction(true)      );});
-    it("false for int",       function() { aver.isFalse( sut.isFunction(123)       );});
-    it("false for string",    function() { aver.isFalse( sut.isFunction("zaza")    );});
-    it("false for []",        function() { aver.isFalse( sut.isFunction([])    );});
+  unit("#isFunction()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isFunction()          );});
+    cs("false for undefined", function() { aver.isFalse( sut.isFunction(undefined) );});
+    cs("false for null",      function() { aver.isFalse( sut.isFunction(null)      );});
+    cs("false for true",      function() { aver.isFalse( sut.isFunction(true)      );});
+    cs("false for int",       function() { aver.isFalse( sut.isFunction(123)       );});
+    cs("false for string",    function() { aver.isFalse( sut.isFunction("zaza")    );});
+    cs("false for []",        function() { aver.isFalse( sut.isFunction([])    );});
 
-    it("false for {}",        function() { aver.isFalse( sut.isFunction({})    );});
+    cs("false for {}",        function() { aver.isFalse( sut.isFunction({})    );});
 
-    it("true for function{}", function() { aver.isTrue( sut.isFunction( function(){}) );});
-    it("true for ()=>true", function() { aver.isTrue( sut.isFunction( () => true ) );});
-    it("true for new Function()",  function() { aver.isTrue( sut.isFunction( new Function("a", "return a*a")) );});
+    cs("true for function{}", function() { aver.isTrue( sut.isFunction( function(){}) );});
+    cs("true for ()=>true", function() { aver.isTrue( sut.isFunction( () => true ) );});
+    cs("true for new Function()",  function() { aver.isTrue( sut.isFunction( new Function("a", "return a*a")) );});
 
 
-    it("true for generator",  function() {
+    cs("true for generator",  function() {
 
       function* gen(){ yield 1; yield 2; }
 
@@ -298,112 +298,112 @@ describe("Types", function() {
   });
 
 
-  describe("#isObjectOrArray()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isObjectOrArray()          );});
-    it("false for undefined", function() { aver.isFalse( sut.isObjectOrArray(undefined) );});
-    it("false for null",      function() { aver.isFalse( sut.isObjectOrArray(null)      );});
-    it("false for true",      function() { aver.isFalse( sut.isObjectOrArray(true)      );});
-    it("false for int",       function() { aver.isFalse( sut.isObjectOrArray(123)       );});
-    it("false for string",    function() { aver.isFalse( sut.isObjectOrArray("zaza")    );});
+  unit("#isObjectOrArray()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isObjectOrArray()          );});
+    cs("false for undefined", function() { aver.isFalse( sut.isObjectOrArray(undefined) );});
+    cs("false for null",      function() { aver.isFalse( sut.isObjectOrArray(null)      );});
+    cs("false for true",      function() { aver.isFalse( sut.isObjectOrArray(true)      );});
+    cs("false for int",       function() { aver.isFalse( sut.isObjectOrArray(123)       );});
+    cs("false for string",    function() { aver.isFalse( sut.isObjectOrArray("zaza")    );});
 
-    it("false for function{}",        function() { aver.isFalse( sut.isObjectOrArray(function(){}) );});
+    cs("false for function{}",        function() { aver.isFalse( sut.isObjectOrArray(function(){}) );});
 
-    it("true for new Date(1)",        function() { aver.isTrue( sut.isObjectOrArray(new Date(1)) );});
-    it("true for new Boolean(true)",  function() { aver.isTrue( sut.isObjectOrArray(new Boolean(true)) );});
-    it("true for new Number(1)",      function() { aver.isTrue( sut.isObjectOrArray(new Number(1)) );});
+    cs("true for new Date(1)",        function() { aver.isTrue( sut.isObjectOrArray(new Date(1)) );});
+    cs("true for new Boolean(true)",  function() { aver.isTrue( sut.isObjectOrArray(new Boolean(true)) );});
+    cs("true for new Number(1)",      function() { aver.isTrue( sut.isObjectOrArray(new Number(1)) );});
 
     //String is "primitive"
-    it("false for 'aaa'",      function() { aver.isFalse( sut.isObjectOrArray("aaa") );});
+    cs("false for 'aaa'",      function() { aver.isFalse( sut.isObjectOrArray("aaa") );});
 
 
-    it("true for []",        function() { aver.isTrue( sut.isObjectOrArray([]) );});
-    it("true for {}",        function() { aver.isTrue( sut.isObjectOrArray({})  );});
-    it("true for {a:1...}",  function() { aver.isTrue( sut.isObjectOrArray({a: 2, b: 3}) );});
+    cs("true for []",        function() { aver.isTrue( sut.isObjectOrArray([]) );});
+    cs("true for {}",        function() { aver.isTrue( sut.isObjectOrArray({})  );});
+    cs("true for {a:1...}",  function() { aver.isTrue( sut.isObjectOrArray({a: 2, b: 3}) );});
 
     function Car(){ this.a=1; }
 
-    it("true for new Car()",  function()    { aver.isTrue( sut.isObjectOrArray(new Car())    );});
-    it("true for [null, null]",  function() { aver.isTrue( sut.isObjectOrArray([null, null]) );});
-    it("true for [1,2,3]",       function() { aver.isTrue( sut.isObjectOrArray([1,2,3])      );});
+    cs("true for new Car()",  function()    { aver.isTrue( sut.isObjectOrArray(new Car())    );});
+    cs("true for [null, null]",  function() { aver.isTrue( sut.isObjectOrArray([null, null]) );});
+    cs("true for [1,2,3]",       function() { aver.isTrue( sut.isObjectOrArray([1,2,3])      );});
   });
 
-  describe("#isObjectOrFunction()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isObjectOrFunction()          );});
-    it("false for undefined", function() { aver.isFalse( sut.isObjectOrFunction(undefined) );});
-    it("false for null",      function() { aver.isFalse( sut.isObjectOrFunction(null)      );});
-    it("false for true",      function() { aver.isFalse( sut.isObjectOrFunction(true)      );});
-    it("false for int",       function() { aver.isFalse( sut.isObjectOrFunction(123)       );});
-    it("false for string",    function() { aver.isFalse( sut.isObjectOrFunction("zaza")    );});
-    it("false for []",        function() { aver.isFalse( sut.isObjectOrFunction([]) );});
+  unit("#isObjectOrFunction()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isObjectOrFunction()          );});
+    cs("false for undefined", function() { aver.isFalse( sut.isObjectOrFunction(undefined) );});
+    cs("false for null",      function() { aver.isFalse( sut.isObjectOrFunction(null)      );});
+    cs("false for true",      function() { aver.isFalse( sut.isObjectOrFunction(true)      );});
+    cs("false for int",       function() { aver.isFalse( sut.isObjectOrFunction(123)       );});
+    cs("false for string",    function() { aver.isFalse( sut.isObjectOrFunction("zaza")    );});
+    cs("false for []",        function() { aver.isFalse( sut.isObjectOrFunction([]) );});
 
-    it("true for new Date(1)",        function() { aver.isTrue( sut.isObjectOrFunction(new Date(1)) );});
-    it("true for new Boolean(true)",  function() { aver.isTrue( sut.isObjectOrFunction(new Boolean(true)) );});
-    it("true for new Number(1)",      function() { aver.isTrue( sut.isObjectOrFunction(new Number(1)) );});
+    cs("true for new Date(1)",        function() { aver.isTrue( sut.isObjectOrFunction(new Date(1)) );});
+    cs("true for new Boolean(true)",  function() { aver.isTrue( sut.isObjectOrFunction(new Boolean(true)) );});
+    cs("true for new Number(1)",      function() { aver.isTrue( sut.isObjectOrFunction(new Number(1)) );});
 
     //String is "primitive"
-    it("false for 'aaa'",      function() { aver.isFalse( sut.isObjectOrFunction("aaa") );});
+    cs("false for 'aaa'",      function() { aver.isFalse( sut.isObjectOrFunction("aaa") );});
 
-    it("true for {}",        function() { aver.isTrue( sut.isObjectOrFunction({})  );});
-    it("true for {a:1...}",  function() { aver.isTrue( sut.isObjectOrFunction({a: 2, b: 3}) );});
+    cs("true for {}",        function() { aver.isTrue( sut.isObjectOrFunction({})  );});
+    cs("true for {a:1...}",  function() { aver.isTrue( sut.isObjectOrFunction({a: 2, b: 3}) );});
 
     function Car(){ this.a=1; }
 
-    it("true for new Car()",      function() { aver.isTrue( sut.isObjectOrFunction(new Car())    );});
-    it("false for [null, null]",  function() { aver.isFalse( sut.isObjectOrFunction([null, null]) );});
+    cs("true for new Car()",      function() { aver.isTrue( sut.isObjectOrFunction(new Car())    );});
+    cs("false for [null, null]",  function() { aver.isFalse( sut.isObjectOrFunction([null, null]) );});
 
-    it("true for function{}",     function() { aver.isTrue( sut.isObjectOrFunction( function(){}) );});
-    it("true for ()=>true",       function() { aver.isTrue( sut.isObjectOrFunction( () => true ) );});
-    it("true for new Function()", function() { aver.isTrue( sut.isObjectOrFunction( new Function("a", "return a*a")) );});
+    cs("true for function{}",     function() { aver.isTrue( sut.isObjectOrFunction( function(){}) );});
+    cs("true for ()=>true",       function() { aver.isTrue( sut.isObjectOrFunction( () => true ) );});
+    cs("true for new Function()", function() { aver.isTrue( sut.isObjectOrFunction( new Function("a", "return a*a")) );});
 
   });
 
 
-  describe("#isIterable()", function() {
-    it("false for empty()",   function() { aver.isFalse( sut.isIterable()          );});
-    it("false for undefined", function() { aver.isFalse( sut.isIterable(undefined) );});
-    it("false for null",      function() { aver.isFalse( sut.isIterable(null)      );});
-    it("false for true",       function() { aver.isFalse( sut.isIterable(true)          );});
-    it("false for new Date(1)",  function() { aver.isFalse( sut.isIterable(new Date(1)) );});
-    it("false for 3",       function() { aver.isFalse( sut.isIterable(3)      );});
-    it("false for {}",      function() { aver.isFalse( sut.isIterable({ })       );});
+  unit("#isIterable()", function() {
+    cs("false for empty()",   function() { aver.isFalse( sut.isIterable()          );});
+    cs("false for undefined", function() { aver.isFalse( sut.isIterable(undefined) );});
+    cs("false for null",      function() { aver.isFalse( sut.isIterable(null)      );});
+    cs("false for true",       function() { aver.isFalse( sut.isIterable(true)          );});
+    cs("false for new Date(1)",  function() { aver.isFalse( sut.isIterable(new Date(1)) );});
+    cs("false for 3",       function() { aver.isFalse( sut.isIterable(3)      );});
+    cs("false for {}",      function() { aver.isFalse( sut.isIterable({ })       );});
 
-    it("true for string",   function() { aver.isTrue( sut.isIterable("")        );});
-    it("true for []",       function() { aver.isTrue( sut.isIterable([])        );});
-    it("true for Map",      function() { aver.isTrue( sut.isIterable(new Map()) );});
-    it("true for Set",      function() { aver.isTrue( sut.isIterable(new Set()) );});
+    cs("true for string",   function() { aver.isTrue( sut.isIterable("")        );});
+    cs("true for []",       function() { aver.isTrue( sut.isIterable([])        );});
+    cs("true for Map",      function() { aver.isTrue( sut.isIterable(new Map()) );});
+    cs("true for Set",      function() { aver.isTrue( sut.isIterable(new Set()) );});
   });
 
 
 
 
-  describe("#describeTypeOf()", function() {
-    it("for ()",   function() { aver.areEqual( "<undefined>", sut.describeTypeOf() );});
-    it("for undefined",   function() { aver.areEqual( "<undefined>", sut.describeTypeOf(undefined) );});
-    it("for null",   function() { aver.areEqual( "<null>", sut.describeTypeOf(null) );});
+  unit("#describeTypeOf()", function() {
+    cs("for ()",   function() { aver.areEqual( "<undefined>", sut.describeTypeOf() );});
+    cs("for undefined",   function() { aver.areEqual( "<undefined>", sut.describeTypeOf(undefined) );});
+    cs("for null",   function() { aver.areEqual( "<null>", sut.describeTypeOf(null) );});
 
-    it("for 1",   function() { aver.areEqual( "number", sut.describeTypeOf(1) );});
-    it("for new Number()",   function() { aver.areEqual( "number", sut.describeTypeOf(new Number(1)) );});
-    it("for 1.3",   function() { aver.areEqual( "number", sut.describeTypeOf(1.3) );});
-    it("for true",   function() { aver.areEqual( "boolean", sut.describeTypeOf(true) );});
-    it("for false",   function() { aver.areEqual( "boolean", sut.describeTypeOf(false) );});
+    cs("for 1",   function() { aver.areEqual( "number", sut.describeTypeOf(1) );});
+    cs("for new Number()",   function() { aver.areEqual( "number", sut.describeTypeOf(new Number(1)) );});
+    cs("for 1.3",   function() { aver.areEqual( "number", sut.describeTypeOf(1.3) );});
+    cs("for true",   function() { aver.areEqual( "boolean", sut.describeTypeOf(true) );});
+    cs("for false",   function() { aver.areEqual( "boolean", sut.describeTypeOf(false) );});
 
-    it("for new Boolean()",   function() { aver.areEqual( "boolean", sut.describeTypeOf(new Boolean(false)) );});
-    it("for ''",   function() { aver.areEqual( "string", sut.describeTypeOf("") );});
-    it("for new String()",   function() { aver.areEqual( "string", sut.describeTypeOf(new String("")) );});
+    cs("for new Boolean()",   function() { aver.areEqual( "boolean", sut.describeTypeOf(new Boolean(false)) );});
+    cs("for ''",   function() { aver.areEqual( "string", sut.describeTypeOf("") );});
+    cs("for new String()",   function() { aver.areEqual( "string", sut.describeTypeOf(new String("")) );});
 
-    it("for Date",   function() { aver.areEqual( "date", sut.describeTypeOf(new Date()) );});
-    it("for []",   function() { aver.areEqual( "array", sut.describeTypeOf([]) );});
-    it("for [1,2,3]",   function() { aver.areEqual( "array", sut.describeTypeOf([1,2,3]) );});
-    it("for {}",   function() { aver.areEqual( "object", sut.describeTypeOf({}) );});
-    it("for {a: 1}",   function() { aver.areEqual( "object", sut.describeTypeOf({a: 1}) );});
+    cs("for Date",   function() { aver.areEqual( "date", sut.describeTypeOf(new Date()) );});
+    cs("for []",   function() { aver.areEqual( "array", sut.describeTypeOf([]) );});
+    cs("for [1,2,3]",   function() { aver.areEqual( "array", sut.describeTypeOf([1,2,3]) );});
+    cs("for {}",   function() { aver.areEqual( "object", sut.describeTypeOf({}) );});
+    cs("for {a: 1}",   function() { aver.areEqual( "object", sut.describeTypeOf({a: 1}) );});
 
 
-    it("for Symbol",   function() {
+    cs("for Symbol",   function() {
       let x = Symbol(9990);
       aver.areEqual( "symbol", sut.describeTypeOf(x) );
     });
 
-    it("for {Iterable}",   function() {
+    cs("for {Iterable}",   function() {
       let x = {
         a: 1, b: true,
         [Symbol.iterator]: function(){ return null; }
@@ -413,9 +413,9 @@ describe("Types", function() {
 
   });
 
-  describe("#nav()", function() {
+  unit("#nav()", function() {
 
-    it("()",   function() {
+    cs("()",   function() {
       let got = sut.nav();
       aver.isNotNull(got);
       aver.isUndefined( got.orig  );
@@ -425,7 +425,7 @@ describe("Types", function() {
       aver.isUndefined( got.result );
     });
 
-    it("({})",   function() {
+    cs("({})",   function() {
       let got = sut.nav({});
       aver.isNotNull(got);
       aver.isNotNull( got.orig  );
@@ -435,7 +435,7 @@ describe("Types", function() {
       aver.isUndefined( got.result );
     });
 
-    it("({},'a')",   function() {
+    cs("({},'a')",   function() {
       let obj = {};
       let got = sut.nav(obj,"a");
       aver.isNotNull(got);
@@ -446,7 +446,7 @@ describe("Types", function() {
       aver.isUndefined(got.result);
     });
 
-    it("({a: 1},'a')",   function() {
+    cs("({a: 1},'a')",   function() {
       let obj = {a: 1};
       let got = sut.nav(obj,"a");
       aver.isNotNull(got);
@@ -457,7 +457,7 @@ describe("Types", function() {
       aver.areEqual(1, got.result);
     });
 
-    it("({a: undefined},'a')",   function() {
+    cs("({a: undefined},'a')",   function() {
       let obj = {a: undefined};
       let got = sut.nav(obj,"a");
       aver.isNotNull(got);
@@ -468,7 +468,7 @@ describe("Types", function() {
       aver.areEqual(undefined, got.result);// undefined is a 100% match (because full=true)
     });
 
-    it("({a: undefined},'a.b.c')",   function() {
+    cs("({a: undefined},'a.b.c')",   function() {
       let obj = {a: undefined};
       let got = sut.nav(obj,"a.b.c");
       aver.isNotNull(got);
@@ -480,7 +480,7 @@ describe("Types", function() {
     });
 
 
-    it("([123, undefined, true],'1')",   function() {
+    cs("([123, undefined, true],'1')",   function() {
       let obj = [123, undefined, true ];
       let got = sut.nav(obj,"1");
       aver.isNotNull(got);
@@ -491,7 +491,7 @@ describe("Types", function() {
       aver.areEqual(undefined, got.result);
     });
 
-    it("([123, {a: {b: 567}}, true ],'1.a.b')",   function() {
+    cs("([123, {a: {b: 567}}, true ],'1.a.b')",   function() {
       let obj = [123, {a: {b: 567}}, true ];
       let got = sut.nav(obj,"1.a.b");
       aver.isNotNull(got);
@@ -502,7 +502,7 @@ describe("Types", function() {
       aver.areEqual(567, got.result);
     });
 
-    it("([123, {a: {b: 567}, q: -9}, true],'1.z.b')",   function() {
+    cs("([123, {a: {b: 567}, q: -9}, true],'1.z.b')",   function() {
       let obj = [123, {a: {b: 567}, q: -9}, true ];
       let got = sut.nav(obj,"1.z.b");
       aver.isNotNull(got);
@@ -513,7 +513,7 @@ describe("Types", function() {
       aver.areEqual(undefined, got.result);
     });
 
-    it("([123, {a: {b: 567, xxx: -877}, q: -9}, true ],'1.a.z')",   function() {
+    cs("([123, {a: {b: 567, xxx: -877}, q: -9}, true ],'1.a.z')",   function() {
       let obj = [123, {a: {b: 567, xxx: -877}, q: -9}, true ];
       let got = sut.nav(obj,"1.a.z");
       aver.isNotNull(got);
@@ -524,7 +524,7 @@ describe("Types", function() {
       aver.areEqual(undefined, got.result);
     });
 
-    it("([123, {a: {b: 567, xxx: -877}, q: -9}, true ],'1.a.xxx')",   function() {
+    cs("([123, {a: {b: 567, xxx: -877}, q: -9}, true ],'1.a.xxx')",   function() {
       let obj = [123, {a: {b: 567, xxx: -877}, q: -9}, true ];
       let got = sut.nav(obj,"1.a.xxx");
       aver.isNotNull(got);
@@ -536,7 +536,7 @@ describe("Types", function() {
     });
 
 
-    it("([123, [[567, 890],-40, -20, [1001, 1002]], true ],'1.0.1')",   function() {
+    cs("([123, [[567, 890],-40, -20, [1001, 1002]], true ],'1.0.1')",   function() {
       let obj = [123, [[567, 890],-40, -20, [1001, 1002]], true ];
       let got = sut.nav(obj,"1.0.1");
       aver.isNotNull(got);
@@ -547,7 +547,7 @@ describe("Types", function() {
       aver.areEqual(890, got.result);
     });
 
-    it("([123, [[567, 890],-40, -20, [1001, 1002]], true ],'1.0.111')",   function() {
+    cs("([123, [[567, 890],-40, -20, [1001, 1002]], true ],'1.0.111')",   function() {
       let obj = [123, [[567, 890],-40, -20, [1001, 1002]], true ];
       let got = sut.nav(obj,"1.0.111");
       aver.isNotNull(got);
@@ -558,7 +558,7 @@ describe("Types", function() {
       aver.areEqual(undefined, got.result);
     });
 
-    it("([123, [[567, 890],-40, -20, [1001, 1002]], true ],'1.2')",   function() {
+    cs("([123, [[567, 890],-40, -20, [1001, 1002]], true ],'1.2')",   function() {
       let obj = [123, [[567, 890],-40, -20, [1001, 1002]], true ];
       let got = sut.nav(obj,"1.2");
       aver.isNotNull(got);
@@ -570,7 +570,7 @@ describe("Types", function() {
     });
 
 
-    it("simple [] path",   function() {
+    cs("simple [] path",   function() {
       let obj = {
         a: 2,
         b: true
@@ -591,7 +591,7 @@ describe("Types", function() {
       aver.areEqual(true, got2.value  );
     });
 
-    it("simple string path",   function() {
+    cs("simple string path",   function() {
       let obj = {
         a: 2,
         b: true
@@ -613,7 +613,7 @@ describe("Types", function() {
     });
 
 
-    it("2 level object path",   function() {
+    cs("2 level object path",   function() {
       let obj = {
         a: {x: 2, y: 3},
         b: "Hello!"
@@ -641,7 +641,7 @@ describe("Types", function() {
       aver.areEqual("Hello!", got3.value  );
     });
 
-    it("2 level object path partial",   function() {
+    cs("2 level object path partial",   function() {
       let obj = {
         a: {x: 2, y: 3, q: 98},
         b: "Hello!"
@@ -657,7 +657,7 @@ describe("Types", function() {
       aver.areEqual(undefined,  got.result  );
     });
 
-    it("3 level object path",   function() {
+    cs("3 level object path",   function() {
       let obj = {
         a: {x: 2, y: 3, q: { name: "abc", descr: "def" }},
         b: "Hello!"
@@ -672,7 +672,7 @@ describe("Types", function() {
       aver.areEqual("def",  got.result );
     });
 
-    it("3 level object/array path",   function() {
+    cs("3 level object/array path",   function() {
       let obj = {
         a: [232, 323, { name: "abc", descr: "def123" }],
         b: "Hello!"
@@ -687,7 +687,7 @@ describe("Types", function() {
       aver.areEqual("def123",  got.result );
     });
 
-    it("3 level chain",   function() {
+    cs("3 level chain",   function() {
       let obj = {
         a: [232, 323, { name: "abc", descr: "def123" }],
         b: "Hello!"
@@ -705,7 +705,7 @@ describe("Types", function() {
       aver.areEqual("def123",  got.result  );
     });
 
-    it("inherit",   function() {
+    cs("inherit",   function() {
 
       function MyClass(a){ this.A = a; }
       MyClass.prototype = {B: {c: 1589, d: 2}};
@@ -722,7 +722,7 @@ describe("Types", function() {
       aver.areEqual(1589,  got.result );
     });
 
-    it("inherit partial",   function() {
+    cs("inherit partial",   function() {
 
       function MyClass(a){ this.A = a; }
       MyClass.prototype = {B: {c: 1589, d: 2}};
@@ -741,14 +741,14 @@ describe("Types", function() {
 
   });
 
-  describe("#mixin()", function() {
-    it("null for (undef, undef)",   function() { aver.isNull( sut.mixin(undefined));  });
-    it("null for (null, null)",   function() { aver.isNull( sut.mixin(null, null));  });
-    it("object for ({})",   function() { aver.isObject( sut.mixin({}) );  });
-    it("object for ({}, null)",   function() { aver.isObject( sut.mixin({}, null));  });
+  unit("#mixin()", function() {
+    cs("null for (undef, undef)",   function() { aver.isNull( sut.mixin(undefined));  });
+    cs("null for (null, null)",   function() { aver.isNull( sut.mixin(null, null));  });
+    cs("object for ({})",   function() { aver.isObject( sut.mixin({}) );  });
+    cs("object for ({}, null)",   function() { aver.isObject( sut.mixin({}, null));  });
 
 
-    it("basically works",   function() {
+    cs("basically works",   function() {
       let a = {};
       let b = {d: 2, e: true};
       let c = sut.mixin(a, b);
@@ -757,7 +757,7 @@ describe("Types", function() {
       aver.isTrue( c.e );
     });
 
-    it("overrides existing",   function() {
+    cs("overrides existing",   function() {
       let a = {d: 4};
       let b = {d: 2, e: true};
       let c = sut.mixin(a, b);
@@ -766,7 +766,7 @@ describe("Types", function() {
       aver.isTrue( c.e );
     });
 
-    it("keeps existing",   function() {
+    cs("keeps existing",   function() {
       let a = {d: 4};
       let b = {d: 2, e: true};
       let c = sut.mixin(a, b, true);
@@ -776,7 +776,7 @@ describe("Types", function() {
     });
 
 
-    it("class this",   function() {
+    cs("class this",   function() {
       let a = new aver.MockA(3, 4);
       let b = {d: 2, e: true};
       let c = sut.mixin(a, b);
@@ -786,7 +786,7 @@ describe("Types", function() {
     });
 
 
-    it("class prototype",   function() {
+    cs("class prototype",   function() {
 
       function classX(){ this.z = 123; }
 
@@ -803,382 +803,382 @@ describe("Types", function() {
   });
 
 
-  describe("#asBool()", function() {
-    it("()",   function() { aver.areEqual( false, sut.asBool() );});
-    it("undefined",   function() { aver.areEqual( false, sut.asBool(undefined) );});
-    it("null",   function() { aver.areEqual( false, sut.asBool(null) );});
+  unit("#asBool()", function() {
+    cs("()",   function() { aver.areEqual( false, sut.asBool() );});
+    cs("undefined",   function() { aver.areEqual( false, sut.asBool(undefined) );});
+    cs("null",   function() { aver.areEqual( false, sut.asBool(null) );});
 
-    it("true",   function() { aver.areEqual( true, sut.asBool(true) );});
-    it("false",   function() { aver.areEqual( false, sut.asBool(false) );});
+    cs("true",   function() { aver.areEqual( true, sut.asBool(true) );});
+    cs("false",   function() { aver.areEqual( false, sut.asBool(false) );});
 
-    it("1",   function() { aver.areEqual( true, sut.asBool(1) );});
-    it("0",   function() { aver.areEqual( false, sut.asBool(0) );});
+    cs("1",   function() { aver.areEqual( true, sut.asBool(1) );});
+    cs("0",   function() { aver.areEqual( false, sut.asBool(0) );});
 
-    it("'1'",   function() { aver.areEqual( true, sut.asBool("1") );});
-    it("' 1'",   function() { aver.areEqual( true, sut.asBool(" 1   ") );});
-    it("ok",   function() { aver.areEqual( true, sut.asBool("  ok  ") );});
-    it("yes",   function() { aver.areEqual( true, sut.asBool("yes") );});
-    it("YES",   function() { aver.areEqual( true, sut.asBool("YES") );});
-    it("TrUE",   function() { aver.areEqual( true, sut.asBool("TrUE") );});
-
-    function Custom(state){
-      this.state = state;
-      this[sut.AS_BOOLEAN_FUN] = function(){ return state; };
-    }
-
-    it("Custom(true)",   function() { aver.areEqual( true, sut.asBool(new Custom(true)) );});
-    it("Custom(false)",   function() { aver.areEqual( false, sut.asBool(new Custom(false)) );});
-    it("Custom(undefined)",   function() { aver.areEqual( false, sut.asBool(new Custom(undefined)) );});
-
-  });
-
-  describe("#asTriBool()", function() {
-    it("()",   function() { aver.areEqual( undefined, sut.asTriBool() );});
-    it("undefined",   function() { aver.areEqual( undefined, sut.asTriBool(undefined) );});
-    it("null",   function() { aver.areEqual( false, sut.asTriBool(null) );});
-
-    it("true",   function() { aver.areEqual( true, sut.asTriBool(true) );});
-    it("false",   function() { aver.areEqual( false, sut.asTriBool(false) );});
-
-    it("1",   function() { aver.areEqual( true, sut.asTriBool(1) );});
-    it("0",   function() { aver.areEqual( false, sut.asTriBool(0) );});
-
-    it("'1'",   function() { aver.areEqual( true, sut.asTriBool("1") );});
-    it("' 1'",   function() { aver.areEqual( true, sut.asTriBool(" 1   ") );});
-    it("ok",   function() { aver.areEqual( true, sut.asTriBool("  ok  ") );});
-    it("yes",   function() { aver.areEqual( true, sut.asTriBool("yes") );});
-    it("YES",   function() { aver.areEqual( true, sut.asTriBool("YES") );});
-    it("TrUE",   function() { aver.areEqual( true, sut.asTriBool("TrUE") );});
+    cs("'1'",   function() { aver.areEqual( true, sut.asBool("1") );});
+    cs("' 1'",   function() { aver.areEqual( true, sut.asBool(" 1   ") );});
+    cs("ok",   function() { aver.areEqual( true, sut.asBool("  ok  ") );});
+    cs("yes",   function() { aver.areEqual( true, sut.asBool("yes") );});
+    cs("YES",   function() { aver.areEqual( true, sut.asBool("YES") );});
+    cs("TrUE",   function() { aver.areEqual( true, sut.asBool("TrUE") );});
 
     function Custom(state){
       this.state = state;
       this[sut.AS_BOOLEAN_FUN] = function(){ return state; };
     }
 
-    it("Custom(true)",   function() { aver.areEqual( true, sut.asTriBool(new Custom(true)) );});
-    it("Custom(false)",   function() { aver.areEqual( false, sut.asTriBool(new Custom(false)) );});
-    it("Custom(undefined)",   function() { aver.areEqual( undefined, sut.asTriBool(new Custom(undefined)) );});
+    cs("Custom(true)",   function() { aver.areEqual( true, sut.asBool(new Custom(true)) );});
+    cs("Custom(false)",   function() { aver.areEqual( false, sut.asBool(new Custom(false)) );});
+    cs("Custom(undefined)",   function() { aver.areEqual( false, sut.asBool(new Custom(undefined)) );});
+
+  });
+
+  unit("#asTriBool()", function() {
+    cs("()",   function() { aver.areEqual( undefined, sut.asTriBool() );});
+    cs("undefined",   function() { aver.areEqual( undefined, sut.asTriBool(undefined) );});
+    cs("null",   function() { aver.areEqual( false, sut.asTriBool(null) );});
+
+    cs("true",   function() { aver.areEqual( true, sut.asTriBool(true) );});
+    cs("false",   function() { aver.areEqual( false, sut.asTriBool(false) );});
+
+    cs("1",   function() { aver.areEqual( true, sut.asTriBool(1) );});
+    cs("0",   function() { aver.areEqual( false, sut.asTriBool(0) );});
+
+    cs("'1'",   function() { aver.areEqual( true, sut.asTriBool("1") );});
+    cs("' 1'",   function() { aver.areEqual( true, sut.asTriBool(" 1   ") );});
+    cs("ok",   function() { aver.areEqual( true, sut.asTriBool("  ok  ") );});
+    cs("yes",   function() { aver.areEqual( true, sut.asTriBool("yes") );});
+    cs("YES",   function() { aver.areEqual( true, sut.asTriBool("YES") );});
+    cs("TrUE",   function() { aver.areEqual( true, sut.asTriBool("TrUE") );});
+
+    function Custom(state){
+      this.state = state;
+      this[sut.AS_BOOLEAN_FUN] = function(){ return state; };
+    }
+
+    cs("Custom(true)",   function() { aver.areEqual( true, sut.asTriBool(new Custom(true)) );});
+    cs("Custom(false)",   function() { aver.areEqual( false, sut.asTriBool(new Custom(false)) );});
+    cs("Custom(undefined)",   function() { aver.areEqual( undefined, sut.asTriBool(new Custom(undefined)) );});
 
   });
 
 
-  describe("#classOf()", function() {
-    it("()",   function() { aver.areEqual( null, sut.classOf() );});
-    it("null",   function() { aver.areEqual( null, sut.classOf(null) );});
-    it("undef",   function() { aver.areEqual( null, sut.classOf(undefined) );});
-    it("123",   function() { aver.areEqual( null, sut.classOf(123) );});
-    it("str",   function() { aver.areEqual( null, sut.classOf(true) );});
+  unit("#classOf()", function() {
+    cs("()",   function() { aver.areEqual( null, sut.classOf() );});
+    cs("null",   function() { aver.areEqual( null, sut.classOf(null) );});
+    cs("undef",   function() { aver.areEqual( null, sut.classOf(undefined) );});
+    cs("123",   function() { aver.areEqual( null, sut.classOf(123) );});
+    cs("str",   function() { aver.areEqual( null, sut.classOf(true) );});
 
-    it("[]",   function() { aver.areEqual( null, sut.classOf([]) );});
+    cs("[]",   function() { aver.areEqual( null, sut.classOf([]) );});
 
-    it("{}",   function() { aver.areEqual( Object, sut.classOf({ }) );});
+    cs("{}",   function() { aver.areEqual( Object, sut.classOf({ }) );});
 
-    it("MockA",   function() { aver.areEqual( aver.MockA, sut.classOf( new aver.MockA()) );});
-    it("MockB",   function() { aver.areEqual( aver.MockB, sut.classOf( new aver.MockB()) );});
-    it("MockBase",   function() { aver.areEqual( aver.MockBase, sut.classOf( new aver.MockBase()) );});
+    cs("MockA",   function() { aver.areEqual( aver.MockA, sut.classOf( new aver.MockA()) );});
+    cs("MockB",   function() { aver.areEqual( aver.MockB, sut.classOf( new aver.MockB()) );});
+    cs("MockBase",   function() { aver.areEqual( aver.MockBase, sut.classOf( new aver.MockBase()) );});
 
   });
 
-  describe("#parentOfClass()", function() {
-    it("()",   function() { aver.areEqual( null, sut.parentOfClass() );});
-    it("null",   function() { aver.areEqual( null, sut.parentOfClass(null) );});
-    it("undef",   function() { aver.areEqual( null, sut.parentOfClass(undefined) );});
-    it("123",   function() { aver.areEqual( null, sut.parentOfClass(123) );});
-    it("bool",   function() { aver.areEqual( null, sut.parentOfClass(true) );});
+  unit("#parentOfClass()", function() {
+    cs("()",   function() { aver.areEqual( null, sut.parentOfClass() );});
+    cs("null",   function() { aver.areEqual( null, sut.parentOfClass(null) );});
+    cs("undef",   function() { aver.areEqual( null, sut.parentOfClass(undefined) );});
+    cs("123",   function() { aver.areEqual( null, sut.parentOfClass(123) );});
+    cs("bool",   function() { aver.areEqual( null, sut.parentOfClass(true) );});
 
-    it("[]",   function() { aver.areEqual( null, sut.parentOfClass([]) );});
+    cs("[]",   function() { aver.areEqual( null, sut.parentOfClass([]) );});
 
-    it("{}",   function() { aver.areEqual( null, sut.parentOfClass({ }) );});
+    cs("{}",   function() { aver.areEqual( null, sut.parentOfClass({ }) );});
 
-    it("MockA",    function() { aver.areEqual( aver.MockBase, sut.parentOfClass( aver.MockA));});
-    it("MockB",    function() { aver.areEqual( aver.MockBase, sut.parentOfClass( aver.MockB)   );});
-    it("MockBC",    function() { aver.areEqual( aver.MockB, sut.parentOfClass( aver.MockBC)   );});
-    it("MockBase", function() { aver.areEqual( null, sut.parentOfClass( aver.MockBase)      );});
+    cs("MockA",    function() { aver.areEqual( aver.MockBase, sut.parentOfClass( aver.MockA));});
+    cs("MockB",    function() { aver.areEqual( aver.MockBase, sut.parentOfClass( aver.MockB)   );});
+    cs("MockBC",    function() { aver.areEqual( aver.MockB, sut.parentOfClass( aver.MockBC)   );});
+    cs("MockBase", function() { aver.areEqual( null, sut.parentOfClass( aver.MockBase)      );});
 
-    it("Chained",    function() { aver.areEqual( aver.MockBase, sut.parentOfClass(sut.parentOfClass( aver.MockBC))  );});
+    cs("Chained",    function() { aver.areEqual( aver.MockBase, sut.parentOfClass(sut.parentOfClass( aver.MockBC))  );});
   });
 
 
-  describe("#isSubclassOf()", function() {
-    it("()",   function() { aver.areEqual( false, sut.isSubclassOf() );});
-    it("null",   function() { aver.areEqual( false, sut.isSubclassOf(null) );});
-    it("undef",   function() { aver.areEqual( false, sut.isSubclassOf(undefined) );});
-    it("123",   function() { aver.areEqual( false, sut.isSubclassOf(123) );});
-    it("bool",   function() { aver.areEqual( false, sut.isSubclassOf(123, true) );});
+  unit("#isSubclassOf()", function() {
+    cs("()",   function() { aver.areEqual( false, sut.isSubclassOf() );});
+    cs("null",   function() { aver.areEqual( false, sut.isSubclassOf(null) );});
+    cs("undef",   function() { aver.areEqual( false, sut.isSubclassOf(undefined) );});
+    cs("123",   function() { aver.areEqual( false, sut.isSubclassOf(123) );});
+    cs("bool",   function() { aver.areEqual( false, sut.isSubclassOf(123, true) );});
 
-    it("MockA(MockBase)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockA, aver.MockBase));});
-    it("MockBase(MockA)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockBase, aver.MockA));});
+    cs("MockA(MockBase)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockA, aver.MockBase));});
+    cs("MockBase(MockA)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockBase, aver.MockA));});
 
-    it("MockA(MockA)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockA, aver.MockA));});
-    it("MockA(object)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockA, Object));});
-    it("MockB(object)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockB, Object));});
-    it("MockBC(object)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockBC, Object));});
+    cs("MockA(MockA)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockA, aver.MockA));});
+    cs("MockA(object)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockA, Object));});
+    cs("MockB(object)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockB, Object));});
+    cs("MockBC(object)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockBC, Object));});
 
-    it("MockA(MockB)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockA, aver.MockB));});
-    it("MockB(MockA)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockB, aver.MockA));});
+    cs("MockA(MockB)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockA, aver.MockB));});
+    cs("MockB(MockA)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockB, aver.MockA));});
 
 
-    it("MockB(MockBase)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockB, aver.MockBase));});
-    it("MockBC(MockBase)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockBC, aver.MockBase));});
-    it("MockBC(MockB)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockBC, aver.MockB));});
+    cs("MockB(MockBase)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockB, aver.MockBase));});
+    cs("MockBC(MockBase)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockBC, aver.MockBase));});
+    cs("MockBC(MockB)",    function() { aver.areEqual( true, sut.isSubclassOf( aver.MockBC, aver.MockB));});
 
-    it("MockBase(MockB)",    function() { aver.areEqual( false, sut.isSubclassOf(aver.MockBase, aver.MockB ));});
-    it("MockBase(MockBC)",    function() { aver.areEqual( false, sut.isSubclassOf(aver.MockBase, aver.MockBC) );});
-    it("MockB(MockBC)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockB, aver.MockBC));});
+    cs("MockBase(MockB)",    function() { aver.areEqual( false, sut.isSubclassOf(aver.MockBase, aver.MockB ));});
+    cs("MockBase(MockBC)",    function() { aver.areEqual( false, sut.isSubclassOf(aver.MockBase, aver.MockBC) );});
+    cs("MockB(MockBC)",    function() { aver.areEqual( false, sut.isSubclassOf( aver.MockB, aver.MockBC));});
   });
 
 
-  describe("#isEmptyIterable()", function() {
-    it("()",    function()    { aver.isTrue( sut.isEmptyIterable() );});
-    it("null",  function()  { aver.isTrue( sut.isEmptyIterable(null) );});
-    it("undef", function() { aver.isTrue(  sut.isEmptyIterable(undefined) );});
-    it("123",   function()   { aver.isTrue( sut.isEmptyIterable(123) );});
-    it("bool",  function()   { aver.isTrue( sut.isEmptyIterable(true) );});
+  unit("#isEmptyIterable()", function() {
+    cs("()",    function()    { aver.isTrue( sut.isEmptyIterable() );});
+    cs("null",  function()  { aver.isTrue( sut.isEmptyIterable(null) );});
+    cs("undef", function() { aver.isTrue(  sut.isEmptyIterable(undefined) );});
+    cs("123",   function()   { aver.isTrue( sut.isEmptyIterable(123) );});
+    cs("bool",  function()   { aver.isTrue( sut.isEmptyIterable(true) );});
 
-    it("[]",    function() { aver.isTrue( sut.isEmptyIterable([]) );});
+    cs("[]",    function() { aver.isTrue( sut.isEmptyIterable([]) );});
 
-    it("{}",    function() { aver.isTrue( sut.isEmptyIterable({ }) );});
+    cs("{}",    function() { aver.isTrue( sut.isEmptyIterable({ }) );});
 
-    it("[1]",      function() { aver.isFalse( sut.isEmptyIterable([1]) );});
-    it("Set(123)", function() { aver.isFalse( sut.isEmptyIterable(new Set([1,2,3])) );});
+    cs("[1]",      function() { aver.isFalse( sut.isEmptyIterable([1]) );});
+    cs("Set(123)", function() { aver.isFalse( sut.isEmptyIterable(new Set([1,2,3])) );});
   });
 
-  describe("#isNonEmptyString()", function() {
-    it("()",    function()  { aver.isFalse( sut.isNonEmptyString() );});
-    it("null",  function()  { aver.isFalse( sut.isNonEmptyString(null) );});
-    it("undef", function()  { aver.isFalse(  sut.isNonEmptyString(undefined) );});
-    it("123",   function()  { aver.isFalse( sut.isNonEmptyString(123) );});
-    it("bool",  function()  { aver.isFalse( sut.isNonEmptyString(true) );});
+  unit("#isNonEmptyString()", function() {
+    cs("()",    function()  { aver.isFalse( sut.isNonEmptyString() );});
+    cs("null",  function()  { aver.isFalse( sut.isNonEmptyString(null) );});
+    cs("undef", function()  { aver.isFalse(  sut.isNonEmptyString(undefined) );});
+    cs("123",   function()  { aver.isFalse( sut.isNonEmptyString(123) );});
+    cs("bool",  function()  { aver.isFalse( sut.isNonEmptyString(true) );});
 
-    it("'          '",  function()  { aver.isFalse( sut.isNonEmptyString("          ") );});
-    it("'  \\r \\n '",  function()  { aver.isFalse( sut.isNonEmptyString("  \r  \n  ") );});
-    it("'aaa'",    function() { aver.isTrue( sut.isNonEmptyString("aaaa") );});
-  });
-
-
-  describe("#asCharCase", function() {
-    it("()",      function()  { aver.areEqual(sut.CHAR_CASE.ASIS,  sut.asCharCase() );});
-    it("(undef)", function()  { aver.areEqual(sut.CHAR_CASE.ASIS,  sut.asCharCase(undefined) );});
-    it("(null)",  function()  { aver.areEqual(sut.CHAR_CASE.ASIS,  sut.asCharCase(null) );});
-    it("(upper)", function()  { aver.areEqual(sut.CHAR_CASE.UPPER,  sut.asCharCase("UppEr") );});
-  });
-
-  describe("#asDataKind", function() {
-    it("()",      () =>  aver.areEqual(sut.DATA_KIND.TEXT,  sut.asDataKind())  );
-    it("(undef)", () =>  aver.areEqual(sut.DATA_KIND.TEXT,  sut.asDataKind(undefined)) );
-    it("(null)",  () =>  aver.areEqual(sut.DATA_KIND.TEXT,  sut.asDataKind(null)) );
-    it("(email)", () =>  aver.areEqual(sut.DATA_KIND.EMAIL, sut.asDataKind("EMaIL")) );
+    cs("'          '",  function()  { aver.isFalse( sut.isNonEmptyString("          ") );});
+    cs("'  \\r \\n '",  function()  { aver.isFalse( sut.isNonEmptyString("  \r  \n  ") );});
+    cs("'aaa'",    function() { aver.isTrue( sut.isNonEmptyString("aaaa") );});
   });
 
 
-  describe("#asTypeMoniker", function() {
-    it("()",      () =>  aver.areEqual(sut.TYPE_MONIKER.STRING,  sut.asTypeMoniker())  );
-    it("(undef)", () =>  aver.areEqual(sut.TYPE_MONIKER.STRING,  sut.asTypeMoniker(undefined)) );
-    it("(null)",  () =>  aver.areEqual(sut.TYPE_MONIKER.STRING,  sut.asTypeMoniker(null)) );
-    it("(int)", () =>  aver.areEqual(sut.TYPE_MONIKER.INT, sut.asTypeMoniker("iNT")) );
-    it("(object)", () =>  aver.areEqual(sut.TYPE_MONIKER.OBJECT, sut.asTypeMoniker("ObjECT")) );
+  unit("#asCharCase", function() {
+    cs("()",      function()  { aver.areEqual(sut.CHAR_CASE.ASIS,  sut.asCharCase() );});
+    cs("(undef)", function()  { aver.areEqual(sut.CHAR_CASE.ASIS,  sut.asCharCase(undefined) );});
+    cs("(null)",  function()  { aver.areEqual(sut.CHAR_CASE.ASIS,  sut.asCharCase(null) );});
+    cs("(upper)", function()  { aver.areEqual(sut.CHAR_CASE.UPPER,  sut.asCharCase("UppEr") );});
+  });
+
+  unit("#asDataKind", function() {
+    cs("()",      () =>  aver.areEqual(sut.DATA_KIND.TEXT,  sut.asDataKind())  );
+    cs("(undef)", () =>  aver.areEqual(sut.DATA_KIND.TEXT,  sut.asDataKind(undefined)) );
+    cs("(null)",  () =>  aver.areEqual(sut.DATA_KIND.TEXT,  sut.asDataKind(null)) );
+    cs("(email)", () =>  aver.areEqual(sut.DATA_KIND.EMAIL, sut.asDataKind("EMaIL")) );
   });
 
 
-  describe("#asInt()", function() {
-    it("()",   function() { aver.areEqual( 0, sut.asInt() );});
-    it("undefined",   function() { aver.areEqual( 0, sut.asInt(undefined) );});
-    it("undefined canUndef",   function() { aver.areEqual( undefined, sut.asInt(undefined, true) );});
-    it("null",   function() { aver.areEqual( 0, sut.asInt(null) );});
-
-    it("true = 1 ",   function() { aver.areEqual( 1, sut.asInt(true) );});
-    it("false = 0 ",   function() { aver.areEqual( 0, sut.asInt(false) );});
-
-    it("1",   function() { aver.areEqual( 1, sut.asInt(1) );});
-    it("0",   function() { aver.areEqual( 0, sut.asInt(0) );});
-    it("-7",   function() { aver.areEqual( -7, sut.asInt(-7) );});
-
-    it("'1'",   function() { aver.areEqual( 1, sut.asInt("1") );});
-    it("'0'",   function() { aver.areEqual( 0, sut.asInt("0") );});
-    it("'-7'",   function() { aver.areEqual( -7, sut.asInt("-7") );});
-
-    it("1.23 = 1",   function() { aver.areEqual( 1, sut.asInt(1.23) );});
-    it("0.99 = 0",   function() { aver.areEqual( 0, sut.asInt(0.99) );});
-    it("-7.97 = -7",   function() { aver.areEqual( -7, sut.asInt(-7.97) );});
-
-    it("'1.23' = 1",   function() { aver.areEqual( 1, sut.asInt("1.23") );});
-    it("'0.99' = 0",   function() { aver.areEqual( 0, sut.asInt("0.99") );});
-    it("'-7.97' = -7",   function() { aver.areEqual( -7, sut.asInt("-7.97") );});
-
-    it("'2gaga' throws",   function() { aver.throws( function(){  sut.asInt("2gaga"); }, "Cast error");});
-
-    it("'0x2a' = 42",   function() { aver.areEqual( 42,  sut.asInt("0x2a") ); });
-    it("' 0x2a ' = 42",   function() { aver.areEqual( 42,  sut.asInt(" 0x2a ") ); });
-    it("' 0xFAcaCA ' = 16435914",   function() { aver.areEqual( 16435914,  sut.asInt(" 0xFAcaCA ") ); });
-
-    it("'0x' throws",   function() { aver.throws( function(){  sut.asInt("0x"); }, "Cast error");});
-    it("'2a' throws",   function() { aver.throws( function(){  sut.asInt("2a"); }, "Cast error");});
-    it("'0x2Z' throws",   function() { aver.throws( function(){  sut.asInt("0x2z"); }, "Cast error");});
-    it("'0xZ2' throws",   function() { aver.throws( function(){  sut.asInt("0xZ2"); }, "Cast error");});
-
-    it("'0b' throws",   function() { aver.throws( function(){  sut.asInt("0b"); }, "Cast error");});
-    it("'0b10' = 2",   function() { aver.areEqual( 2,  sut.asInt("0b10") ); });
-    it("' 0b11 ' = 3",   function() { aver.areEqual( 3,  sut.asInt(" 0b11 ") ); });
-    it("' 0b11110000 ' = 240",   function() { aver.areEqual( 240,  sut.asInt(" 0b11110000 ") ); });
-
-    it("'0b21' throws",   function() { aver.throws( function(){  sut.asInt("0b21"); }, "Cast error");});
-    it("'0b1Z' throws",   function() { aver.throws( function(){  sut.asInt("0b1Z"); }, "Cast error");});
+  unit("#asTypeMoniker", function() {
+    cs("()",      () =>  aver.areEqual(sut.TYPE_MONIKER.STRING,  sut.asTypeMoniker())  );
+    cs("(undef)", () =>  aver.areEqual(sut.TYPE_MONIKER.STRING,  sut.asTypeMoniker(undefined)) );
+    cs("(null)",  () =>  aver.areEqual(sut.TYPE_MONIKER.STRING,  sut.asTypeMoniker(null)) );
+    cs("(int)", () =>  aver.areEqual(sut.TYPE_MONIKER.INT, sut.asTypeMoniker("iNT")) );
+    cs("(object)", () =>  aver.areEqual(sut.TYPE_MONIKER.OBJECT, sut.asTypeMoniker("ObjECT")) );
+  });
 
 
+  unit("#asInt()", function() {
+    cs("()",   function() { aver.areEqual( 0, sut.asInt() );});
+    cs("undefined",   function() { aver.areEqual( 0, sut.asInt(undefined) );});
+    cs("undefined canUndef",   function() { aver.areEqual( undefined, sut.asInt(undefined, true) );});
+    cs("null",   function() { aver.areEqual( 0, sut.asInt(null) );});
 
-    it("'-7e3' = -7000",   function() { aver.areEqual( -7000, sut.asInt("-7e3") );});
-    it("'-7e-3' = 0",   function() { aver.areEqual( 0, sut.asInt("-7e-3") );});
-    it("'-7e--3' throws",   function() { aver.throws( function(){  sut.asInt("-7e--3"); }, "Cast error");});
+    cs("true = 1 ",   function() { aver.areEqual( 1, sut.asInt(true) );});
+    cs("false = 0 ",   function() { aver.areEqual( 0, sut.asInt(false) );});
 
-    it("'+7e3' = 7000",   function() { aver.areEqual( 7000, sut.asInt("+7e3") );});
-    it("'++7e3' throws",   function() { aver.throws( function(){  sut.asInt("++7e3"); }, "Cast error");});
+    cs("1",   function() { aver.areEqual( 1, sut.asInt(1) );});
+    cs("0",   function() { aver.areEqual( 0, sut.asInt(0) );});
+    cs("-7",   function() { aver.areEqual( -7, sut.asInt(-7) );});
 
-    it("'2..3' throws",   function() { aver.throws( function(){  sut.asInt("2..3"); }, "Cast error");});
-    it("'2-3' throws",   function() { aver.throws( function(){  sut.asInt("2-3"); }, "Cast error");});
+    cs("'1'",   function() { aver.areEqual( 1, sut.asInt("1") );});
+    cs("'0'",   function() { aver.areEqual( 0, sut.asInt("0") );});
+    cs("'-7'",   function() { aver.areEqual( -7, sut.asInt("-7") );});
 
-    it("Date(123)",   function() { aver.areEqual( 123, sut.asInt(new Date(123)) );});
+    cs("1.23 = 1",   function() { aver.areEqual( 1, sut.asInt(1.23) );});
+    cs("0.99 = 0",   function() { aver.areEqual( 0, sut.asInt(0.99) );});
+    cs("-7.97 = -7",   function() { aver.areEqual( -7, sut.asInt(-7.97) );});
+
+    cs("'1.23' = 1",   function() { aver.areEqual( 1, sut.asInt("1.23") );});
+    cs("'0.99' = 0",   function() { aver.areEqual( 0, sut.asInt("0.99") );});
+    cs("'-7.97' = -7",   function() { aver.areEqual( -7, sut.asInt("-7.97") );});
+
+    cs("'2gaga' throws",   function() { aver.throws( function(){  sut.asInt("2gaga"); }, "Cast error");});
+
+    cs("'0x2a' = 42",   function() { aver.areEqual( 42,  sut.asInt("0x2a") ); });
+    cs("' 0x2a ' = 42",   function() { aver.areEqual( 42,  sut.asInt(" 0x2a ") ); });
+    cs("' 0xFAcaCA ' = 16435914",   function() { aver.areEqual( 16435914,  sut.asInt(" 0xFAcaCA ") ); });
+
+    cs("'0x' throws",   function() { aver.throws( function(){  sut.asInt("0x"); }, "Cast error");});
+    cs("'2a' throws",   function() { aver.throws( function(){  sut.asInt("2a"); }, "Cast error");});
+    cs("'0x2Z' throws",   function() { aver.throws( function(){  sut.asInt("0x2z"); }, "Cast error");});
+    cs("'0xZ2' throws",   function() { aver.throws( function(){  sut.asInt("0xZ2"); }, "Cast error");});
+
+    cs("'0b' throws",   function() { aver.throws( function(){  sut.asInt("0b"); }, "Cast error");});
+    cs("'0b10' = 2",   function() { aver.areEqual( 2,  sut.asInt("0b10") ); });
+    cs("' 0b11 ' = 3",   function() { aver.areEqual( 3,  sut.asInt(" 0b11 ") ); });
+    cs("' 0b11110000 ' = 240",   function() { aver.areEqual( 240,  sut.asInt(" 0b11110000 ") ); });
+
+    cs("'0b21' throws",   function() { aver.throws( function(){  sut.asInt("0b21"); }, "Cast error");});
+    cs("'0b1Z' throws",   function() { aver.throws( function(){  sut.asInt("0b1Z"); }, "Cast error");});
+
+
+
+    cs("'-7e3' = -7000",   function() { aver.areEqual( -7000, sut.asInt("-7e3") );});
+    cs("'-7e-3' = 0",   function() { aver.areEqual( 0, sut.asInt("-7e-3") );});
+    cs("'-7e--3' throws",   function() { aver.throws( function(){  sut.asInt("-7e--3"); }, "Cast error");});
+
+    cs("'+7e3' = 7000",   function() { aver.areEqual( 7000, sut.asInt("+7e3") );});
+    cs("'++7e3' throws",   function() { aver.throws( function(){  sut.asInt("++7e3"); }, "Cast error");});
+
+    cs("'2..3' throws",   function() { aver.throws( function(){  sut.asInt("2..3"); }, "Cast error");});
+    cs("'2-3' throws",   function() { aver.throws( function(){  sut.asInt("2-3"); }, "Cast error");});
+
+    cs("Date(123)",   function() { aver.areEqual( 123, sut.asInt(new Date(123)) );});
 
     function Custom(state){
       this.state = state;
       this[sut.AS_INTEGER_FUN] = function(){ return state; };
     }
 
-    it("Custom(12)",   function() { aver.areEqual( 12, sut.asInt(new Custom(12)) );});
-    it("Custom(-800)",   function() { aver.areEqual( -800, sut.asInt(new Custom(-800)) );});
+    cs("Custom(12)",   function() { aver.areEqual( 12, sut.asInt(new Custom(12)) );});
+    cs("Custom(-800)",   function() { aver.areEqual( -800, sut.asInt(new Custom(-800)) );});
 
-    it("Custom('12')",   function() { aver.areEqual( 12, sut.asInt(new Custom("12")) );});
-    it("Custom('-800')",   function() { aver.areEqual( -800, sut.asInt(new Custom("-800.999")) );});
-    it("Custom(undefined)",   function() { aver.areEqual( 0, sut.asInt(new Custom(undefined)) );});
-    it("Custom(undefined) canUndef",   function() { aver.areEqual( undefined, sut.asInt(new Custom(undefined), true) );});
-
-  });
-
-  describe("#asReal()", function() {
-    it("()",   function() { aver.areEqual( 0, sut.asReal() );});
-    it("undefined",   function() { aver.areEqual( 0, sut.asReal(undefined) );});
-    it("undefined canUndef",   function() { aver.areEqual( undefined, sut.asReal(undefined, true) );});
-    it("null",   function() { aver.areEqual( 0, sut.asReal(null) );});
-
-    it("true = 1 ",   function() { aver.areEqual( 1, sut.asReal(true) );});
-    it("false = 0 ",   function() { aver.areEqual( 0, sut.asReal(false) );});
-
-    it("1",   function() { aver.areEqual( 1, sut.asReal(1) );});
-    it("0",   function() { aver.areEqual( 0, sut.asReal(0) );});
-    it("-7",   function() { aver.areEqual( -7, sut.asReal(-7) );});
-
-    it("'1'",   function() { aver.areEqual( 1, sut.asReal("1") );});
-    it("'0'",   function() { aver.areEqual( 0, sut.asReal("0") );});
-    it("'-7'",   function() { aver.areEqual( -7, sut.asReal("-7") );});
-
-
-    it("1.23 = 1.23",   function() { aver.areEqual( 1.23, sut.asReal(1.23) );});
-    it("0.99 = 0.99",   function() { aver.areEqual( 0.99, sut.asReal(0.99) );});
-    it("-7.97 = -7.97",   function() { aver.areEqual( -7.97, sut.asReal(-7.97) );});
-
-    it("'1.23' = 1.23",   function() { aver.areEqual( 1.23, sut.asReal("1.23") );});
-    it("'0.99' = 0.99",   function() { aver.areEqual( 0.99, sut.asReal("0.99") );});
-    it("'-7.97' = -7.97",   function() { aver.areEqual( -7.97, sut.asReal("-7.97") );});
-
-
-    it("'2gaga' throws",   function() { aver.throws( function(){  sut.asReal("2gaga"); }, "Cast error");});
-
-
-    it("'-7e3' = -7000",   function() { aver.areEqual( -7000, sut.asReal("-7e3") );});
-    it("'-7e-3' = -0.007",   function() { aver.areEqual( -0.007, sut.asReal("-7e-3") );});
-    it("'+7e-3' = 0.007",   function() { aver.areEqual( 0.007, sut.asReal("7e-3") );});
-    it("'-7e--3' throws",   function() { aver.throws( function(){  sut.asReal("-7e--3"); }, "Cast error");});
-
-    it("'+7e3' = 7000",   function() { aver.areEqual( 7000, sut.asReal("+7e3") );});
-    it("'++7e3' throws",   function() { aver.throws( function(){  sut.asReal("++7e3"); }, "Cast error");});
-
-    it("'2..3' throws",   function() { aver.throws( function(){  sut.asReal("2..3"); }, "Cast error");});
-    it("'2-3' throws",   function() { aver.throws( function(){  sut.asReal("2-3"); }, "Cast error");});
-
-
-    it("Date(123)",   function() { aver.areEqual( 123, sut.asReal(new Date(123)) );});
+    cs("Custom('12')",   function() { aver.areEqual( 12, sut.asInt(new Custom("12")) );});
+    cs("Custom('-800')",   function() { aver.areEqual( -800, sut.asInt(new Custom("-800.999")) );});
+    cs("Custom(undefined)",   function() { aver.areEqual( 0, sut.asInt(new Custom(undefined)) );});
+    cs("Custom(undefined) canUndef",   function() { aver.areEqual( undefined, sut.asInt(new Custom(undefined), true) );});
 
   });
 
-  describe("#asMoney()", function() {
-    it("()",   function() { aver.areEqual( 0, sut.asMoney() );});
-    it("undefined",   function() { aver.areEqual( 0, sut.asMoney(undefined) );});
-    it("undefined canUndef",   function() { aver.areEqual( undefined, sut.asMoney(undefined, true) );});
-    it("null",   function() { aver.areEqual( 0, sut.asMoney(null) );});
+  unit("#asReal()", function() {
+    cs("()",   function() { aver.areEqual( 0, sut.asReal() );});
+    cs("undefined",   function() { aver.areEqual( 0, sut.asReal(undefined) );});
+    cs("undefined canUndef",   function() { aver.areEqual( undefined, sut.asReal(undefined, true) );});
+    cs("null",   function() { aver.areEqual( 0, sut.asReal(null) );});
 
-    it("true = 1 ",   function() { aver.areEqual( 1, sut.asMoney(true) );});
-    it("false = 0 ",   function() { aver.areEqual( 0, sut.asMoney(false) );});
+    cs("true = 1 ",   function() { aver.areEqual( 1, sut.asReal(true) );});
+    cs("false = 0 ",   function() { aver.areEqual( 0, sut.asReal(false) );});
 
-    it("1",   function() { aver.areEqual( 1, sut.asMoney(1) );});
-    it("0",   function() { aver.areEqual( 0, sut.asMoney(0) );});
-    it("-7",   function() { aver.areEqual( -7, sut.asMoney(-7) );});
+    cs("1",   function() { aver.areEqual( 1, sut.asReal(1) );});
+    cs("0",   function() { aver.areEqual( 0, sut.asReal(0) );});
+    cs("-7",   function() { aver.areEqual( -7, sut.asReal(-7) );});
 
-    it("'1'",   function() { aver.areEqual( 1, sut.asMoney("1") );});
-    it("'0'",   function() { aver.areEqual( 0, sut.asMoney("0") );});
-    it("'-7'",   function() { aver.areEqual( -7, sut.asMoney("-7") );});
-
-    it("1.23 = 1.23",   function() { aver.areEqual( 1.23, sut.asMoney(1.23) );});
-    it("0.99 = 0.99",   function() { aver.areEqual( 0.99, sut.asMoney(0.99) );});
-    it("-7.97 = -7.97",   function() { aver.areEqual( -7.97, sut.asMoney(-7.97) );});
-
-    it("'1.23' = 1.23",   function() { aver.areEqual( 1.23, sut.asMoney("1.23") );});
-    it("'0.99' = 0.99",   function() { aver.areEqual( 0.99, sut.asMoney("0.99") );});
-    it("'-7.97' = -7.97",   function() { aver.areEqual( -7.97, sut.asMoney("-7.97") );});
+    cs("'1'",   function() { aver.areEqual( 1, sut.asReal("1") );});
+    cs("'0'",   function() { aver.areEqual( 0, sut.asReal("0") );});
+    cs("'-7'",   function() { aver.areEqual( -7, sut.asReal("-7") );});
 
 
-    it("'2gaga' throws",   function() { aver.throws( function(){  sut.asMoney("2gaga"); }, "Cast error");});
+    cs("1.23 = 1.23",   function() { aver.areEqual( 1.23, sut.asReal(1.23) );});
+    cs("0.99 = 0.99",   function() { aver.areEqual( 0.99, sut.asReal(0.99) );});
+    cs("-7.97 = -7.97",   function() { aver.areEqual( -7.97, sut.asReal(-7.97) );});
+
+    cs("'1.23' = 1.23",   function() { aver.areEqual( 1.23, sut.asReal("1.23") );});
+    cs("'0.99' = 0.99",   function() { aver.areEqual( 0.99, sut.asReal("0.99") );});
+    cs("'-7.97' = -7.97",   function() { aver.areEqual( -7.97, sut.asReal("-7.97") );});
 
 
-    it("'-7e3' = -7000",   function() { aver.areEqual( -7000, sut.asMoney("-7e3") );});
-    it("'-12345e-5' = -0.1234",   function() { aver.areEqual( -0.1234, sut.asMoney("-12345e-5") );});
-    it("'+7e-3' = 0.007",   function() { aver.areEqual( 0.007, sut.asMoney("7e-3") );});
-    it("'+7e-5' = 0",   function() { aver.areEqual( 0, sut.asMoney("7e-5") );});
-    it("'-7e--3' throws",   function() { aver.throws( function(){  sut.asMoney("-7e--3"); }, "Cast error");});
-
-    it("'+7e3' = 7000",   function() { aver.areEqual( 7000, sut.asMoney("+7e3") );});
-    it("'++7e3' throws",   function() { aver.throws( function(){  sut.asMoney("++7e3"); }, "Cast error");});
-
-    it("'2..3' throws",   function() { aver.throws( function(){  sut.asMoney("2..3"); }, "Cast error");});
-    it("'2-3' throws",   function() { aver.throws( function(){  sut.asMoney("2-3"); }, "Cast error");});
+    cs("'2gaga' throws",   function() { aver.throws( function(){  sut.asReal("2gaga"); }, "Cast error");});
 
 
-    it("Date(123)",   function() { aver.areEqual( 123, sut.asMoney(new Date(123)) );});
+    cs("'-7e3' = -7000",   function() { aver.areEqual( -7000, sut.asReal("-7e3") );});
+    cs("'-7e-3' = -0.007",   function() { aver.areEqual( -0.007, sut.asReal("-7e-3") );});
+    cs("'+7e-3' = 0.007",   function() { aver.areEqual( 0.007, sut.asReal("7e-3") );});
+    cs("'-7e--3' throws",   function() { aver.throws( function(){  sut.asReal("-7e--3"); }, "Cast error");});
 
-    it("45/8.17 = 5.5079(55936...)",   function() { aver.areEqual( 5.5079, sut.asMoney(45/8.17) );});
+    cs("'+7e3' = 7000",   function() { aver.areEqual( 7000, sut.asReal("+7e3") );});
+    cs("'++7e3' throws",   function() { aver.throws( function(){  sut.asReal("++7e3"); }, "Cast error");});
 
-    it("10/3 = 3.3333(3333333...)",   function() { aver.areEqual( 3.3333, sut.asMoney(10/3) );});
+    cs("'2..3' throws",   function() { aver.throws( function(){  sut.asReal("2..3"); }, "Cast error");});
+    cs("'2-3' throws",   function() { aver.throws( function(){  sut.asReal("2-3"); }, "Cast error");});
 
-    it("10/2.876 = 3.4770(5146....)",   function() { aver.areEqual( 3.4770, sut.asMoney(10/2.876) );});
+
+    cs("Date(123)",   function() { aver.areEqual( 123, sut.asReal(new Date(123)) );});
+
+  });
+
+  unit("#asMoney()", function() {
+    cs("()",   function() { aver.areEqual( 0, sut.asMoney() );});
+    cs("undefined",   function() { aver.areEqual( 0, sut.asMoney(undefined) );});
+    cs("undefined canUndef",   function() { aver.areEqual( undefined, sut.asMoney(undefined, true) );});
+    cs("null",   function() { aver.areEqual( 0, sut.asMoney(null) );});
+
+    cs("true = 1 ",   function() { aver.areEqual( 1, sut.asMoney(true) );});
+    cs("false = 0 ",   function() { aver.areEqual( 0, sut.asMoney(false) );});
+
+    cs("1",   function() { aver.areEqual( 1, sut.asMoney(1) );});
+    cs("0",   function() { aver.areEqual( 0, sut.asMoney(0) );});
+    cs("-7",   function() { aver.areEqual( -7, sut.asMoney(-7) );});
+
+    cs("'1'",   function() { aver.areEqual( 1, sut.asMoney("1") );});
+    cs("'0'",   function() { aver.areEqual( 0, sut.asMoney("0") );});
+    cs("'-7'",   function() { aver.areEqual( -7, sut.asMoney("-7") );});
+
+    cs("1.23 = 1.23",   function() { aver.areEqual( 1.23, sut.asMoney(1.23) );});
+    cs("0.99 = 0.99",   function() { aver.areEqual( 0.99, sut.asMoney(0.99) );});
+    cs("-7.97 = -7.97",   function() { aver.areEqual( -7.97, sut.asMoney(-7.97) );});
+
+    cs("'1.23' = 1.23",   function() { aver.areEqual( 1.23, sut.asMoney("1.23") );});
+    cs("'0.99' = 0.99",   function() { aver.areEqual( 0.99, sut.asMoney("0.99") );});
+    cs("'-7.97' = -7.97",   function() { aver.areEqual( -7.97, sut.asMoney("-7.97") );});
+
+
+    cs("'2gaga' throws",   function() { aver.throws( function(){  sut.asMoney("2gaga"); }, "Cast error");});
+
+
+    cs("'-7e3' = -7000",   function() { aver.areEqual( -7000, sut.asMoney("-7e3") );});
+    cs("'-12345e-5' = -0.1234",   function() { aver.areEqual( -0.1234, sut.asMoney("-12345e-5") );});
+    cs("'+7e-3' = 0.007",   function() { aver.areEqual( 0.007, sut.asMoney("7e-3") );});
+    cs("'+7e-5' = 0",   function() { aver.areEqual( 0, sut.asMoney("7e-5") );});
+    cs("'-7e--3' throws",   function() { aver.throws( function(){  sut.asMoney("-7e--3"); }, "Cast error");});
+
+    cs("'+7e3' = 7000",   function() { aver.areEqual( 7000, sut.asMoney("+7e3") );});
+    cs("'++7e3' throws",   function() { aver.throws( function(){  sut.asMoney("++7e3"); }, "Cast error");});
+
+    cs("'2..3' throws",   function() { aver.throws( function(){  sut.asMoney("2..3"); }, "Cast error");});
+    cs("'2-3' throws",   function() { aver.throws( function(){  sut.asMoney("2-3"); }, "Cast error");});
+
+
+    cs("Date(123)",   function() { aver.areEqual( 123, sut.asMoney(new Date(123)) );});
+
+    cs("45/8.17 = 5.5079(55936...)",   function() { aver.areEqual( 5.5079, sut.asMoney(45/8.17) );});
+
+    cs("10/3 = 3.3333(3333333...)",   function() { aver.areEqual( 3.3333, sut.asMoney(10/3) );});
+
+    cs("10/2.876 = 3.4770(5146....)",   function() { aver.areEqual( 3.4770, sut.asMoney(10/2.876) );});
   });
 
 
-  describe("#asDate()", function() {
+  unit("#asDate()", function() {
 
     const ZERO = new Date(0);
 
-    it("()",   function() { aver.areEqualValues( ZERO, sut.asDate() );});
-    it("undefined",   function() { aver.areEqualValues( ZERO, sut.asDate(undefined) );});
-    it("undefined canUndef",   function() { aver.areEqualValues( undefined, sut.asDate(undefined, true) );});
-    it("null",   function() { aver.areEqualValues( ZERO, sut.asDate(null) );});
+    cs("()",   function() { aver.areEqualValues( ZERO, sut.asDate() );});
+    cs("undefined",   function() { aver.areEqualValues( ZERO, sut.asDate(undefined) );});
+    cs("undefined canUndef",   function() { aver.areEqualValues( undefined, sut.asDate(undefined, true) );});
+    cs("null",   function() { aver.areEqualValues( ZERO, sut.asDate(null) );});
 
-    it("true throws",   function() { aver.throws( function(){  sut.asDate(true); }, "Cast error");});
-    it("false throws",   function() { aver.throws( function(){  sut.asDate(false); }, "Cast error");});
+    cs("true throws",   function() { aver.throws( function(){  sut.asDate(true); }, "Cast error");});
+    cs("false throws",   function() { aver.throws( function(){  sut.asDate(false); }, "Cast error");});
 
-    it("1",   function() { aver.areEqualValues( new Date(1), sut.asDate(1) );});
-    it("0",   function() { aver.areEqualValues( ZERO, sut.asDate(0) );});
-    it("-7",   function() { aver.areEqualValues( new Date(-7), sut.asDate(-7) );});
+    cs("1",   function() { aver.areEqualValues( new Date(1), sut.asDate(1) );});
+    cs("0",   function() { aver.areEqualValues( ZERO, sut.asDate(0) );});
+    cs("-7",   function() { aver.areEqualValues( new Date(-7), sut.asDate(-7) );});
 
-    it("'1'",   function() { aver.areEqualValues( new Date(1), sut.asDate("1") );});
-    it("'0'",   function() { aver.areEqualValues( ZERO, sut.asDate("0") );});
-    it("'-7'",   function() { aver.areEqualValues( new Date(-7), sut.asDate("-7") );});
+    cs("'1'",   function() { aver.areEqualValues( new Date(1), sut.asDate("1") );});
+    cs("'0'",   function() { aver.areEqualValues( ZERO, sut.asDate("0") );});
+    cs("'-7'",   function() { aver.areEqualValues( new Date(-7), sut.asDate("-7") );});
 
-    it("April 12, 2012",   function() {
+    cs("April 12, 2012",   function() {
       const d = sut.asDate(" April 12, 2012");
       aver.areEqual( 3, d.getMonth() );
       aver.areEqual( 12, d.getDate() );
       aver.areEqual( 2012, d.getFullYear() );
     });
 
-    it("2024-12-31T00:00:00+00:00 !fromUTC", function() {
+    cs("2024-12-31T00:00:00+00:00 !fromUTC", function() {
       const d = sut.asDate("2024-12-31T00:00:00Z", false);
       aver.areEqual(11, d.getUTCMonth());
       aver.areEqual(31, d.getUTCDate());
@@ -1189,30 +1189,30 @@ describe("Types", function() {
       aver.areEqual(0, d.getUTCMilliseconds());
     });
 
-    it("abrakadabra throws",   function() { aver.throws( function(){  sut.asDate("abrakadabra"); }, "Cast error");});
+    cs("abrakadabra throws",   function() { aver.throws( function(){  sut.asDate("abrakadabra"); }, "Cast error");});
   });
 
 
-  describe("#asObject()", function() {
+  unit("#asObject()", function() {
 
-    it("()",   function() { aver.areEqualValues( null, sut.asObject() );});
-    it("undefined",   function() { aver.areEqualValues( null, sut.asObject(undefined) );});
-    it("undefined canUndef",   function() { aver.areEqualValues( undefined, sut.asObject(undefined, true) );});
-    it("null",   function() { aver.areEqualValues( null, sut.asObject(null) );});
+    cs("()",   function() { aver.areEqualValues( null, sut.asObject() );});
+    cs("undefined",   function() { aver.areEqualValues( null, sut.asObject(undefined) );});
+    cs("undefined canUndef",   function() { aver.areEqualValues( undefined, sut.asObject(undefined, true) );});
+    cs("null",   function() { aver.areEqualValues( null, sut.asObject(null) );});
 
-    it("true throws",   function() { aver.throws( function(){  sut.asObject(true); }, "Cast error");});
-    it("false throws",   function() { aver.throws( function(){  sut.asObject(false); }, "Cast error");});
+    cs("true throws",   function() { aver.throws( function(){  sut.asObject(true); }, "Cast error");});
+    cs("false throws",   function() { aver.throws( function(){  sut.asObject(false); }, "Cast error");});
 
-    it("1 throws",   function() { aver.throws( function(){  sut.asObject(1); }, "Cast error");});
-    it("'1' throws",   function() { aver.throws( function(){  sut.asObject("1"); }, "Cast error");});
+    cs("1 throws",   function() { aver.throws( function(){  sut.asObject(1); }, "Cast error");});
+    cs("'1' throws",   function() { aver.throws( function(){  sut.asObject("1"); }, "Cast error");});
 
-    it("[] throws",   function() { aver.throws( function(){  sut.asObject([]); }, "Cast error");});
-    it("'[]' throws",   function() { aver.throws( function(){  sut.asObject("[]"); }, "Cast error");});
+    cs("[] throws",   function() { aver.throws( function(){  sut.asObject([]); }, "Cast error");});
+    cs("'[]' throws",   function() { aver.throws( function(){  sut.asObject("[]"); }, "Cast error");});
 
-    it("{}",   function() { aver.isObject( sut.asObject({})  );});
-    it("'{}'",   function() { aver.isObject( sut.asObject("{}")  );});
+    cs("{}",   function() { aver.isObject( sut.asObject({})  );});
+    cs("'{}'",   function() { aver.isObject( sut.asObject("{}")  );});
 
-    it("{a: 1, b: 234, c: true, d: [7,8,9]}",   function() {
+    cs("{a: 1, b: 234, c: true, d: [7,8,9]}",   function() {
       const o = sut.asObject({a: 1, b: 234, c: true, d: [7,8,9]});
       aver.isObject( o );
       aver.areEqual(1, o.a);
@@ -1221,7 +1221,7 @@ describe("Types", function() {
       aver.areArraysEquivalent([7,8,9], o.d);
     });
 
-    it("'{a: 1, b: 234, c: true, d: [7,8,9]}'",   function() {
+    cs("'{a: 1, b: 234, c: true, d: [7,8,9]}'",   function() {
       const o = sut.asObject("{\"a\": 1, \"b\": 234, \"c\": true, \"d\": [7,8,9]}");
       aver.isObject( o );
       aver.areEqual(1, o.a);
@@ -1230,41 +1230,41 @@ describe("Types", function() {
       aver.areArraysEquivalent([7,8,9], o.d);
     });
 
-    it("'{a: 2...' throws",   function() { aver.throws( function(){  sut.asObject("{\"a\": 2..."); }, "Cast error");});
+    cs("'{a: 2...' throws",   function() { aver.throws( function(){  sut.asObject("{\"a\": 2..."); }, "Cast error");});
   });
 
-  describe("#asArray()", function() {
+  unit("#asArray()", function() {
 
-    it("()",   function() { aver.areEqualValues( null, sut.asArray() );});
-    it("undefined",   function() { aver.areEqualValues( null, sut.asArray(undefined) );});
-    it("undefined canUndef",   function() { aver.areEqualValues( undefined, sut.asArray(undefined, true) );});
-    it("null",   function() { aver.areEqualValues( null, sut.asArray(null) );});
+    cs("()",   function() { aver.areEqualValues( null, sut.asArray() );});
+    cs("undefined",   function() { aver.areEqualValues( null, sut.asArray(undefined) );});
+    cs("undefined canUndef",   function() { aver.areEqualValues( undefined, sut.asArray(undefined, true) );});
+    cs("null",   function() { aver.areEqualValues( null, sut.asArray(null) );});
 
-    it("true throws",   function() { aver.throws( function(){  sut.asArray(true); }, "Cast error");});
-    it("false throws",   function() { aver.throws( function(){  sut.asArray(false); }, "Cast error");});
+    cs("true throws",   function() { aver.throws( function(){  sut.asArray(true); }, "Cast error");});
+    cs("false throws",   function() { aver.throws( function(){  sut.asArray(false); }, "Cast error");});
 
-    it("1 throws",   function() { aver.throws( function(){  sut.asArray(1); }, "Cast error");});
-    it("'1' throws",   function() { aver.throws( function(){  sut.asArray("1"); }, "Cast error");});
+    cs("1 throws",   function() { aver.throws( function(){  sut.asArray(1); }, "Cast error");});
+    cs("'1' throws",   function() { aver.throws( function(){  sut.asArray("1"); }, "Cast error");});
 
-    it("{} throws",   function() { aver.throws( function(){  sut.asArray({}); }, "Cast error");});
-    it("'{}' throws",   function() { aver.throws( function(){  sut.asArray("{}"); }, "Cast error");});
+    cs("{} throws",   function() { aver.throws( function(){  sut.asArray({}); }, "Cast error");});
+    cs("'{}' throws",   function() { aver.throws( function(){  sut.asArray("{}"); }, "Cast error");});
 
-    it("[]",   function() { aver.areArraysEquivalent([], sut.asArray([])  );});
-    it("'[]'",   function() { aver.areArraysEquivalent([], sut.asArray("[]")  );});
+    cs("[]",   function() { aver.areArraysEquivalent([], sut.asArray([])  );});
+    cs("'[]'",   function() { aver.areArraysEquivalent([], sut.asArray("[]")  );});
 
-    it("[1, -2, 3, true, 'abc']",   function() {
+    cs("[1, -2, 3, true, 'abc']",   function() {
       const a = sut.asArray([1, -2, 3, true, "abc"]);
       aver.isArray( a );
       aver.areArraysEquivalent([1,-2,3,true,"abc"], a);
     });
 
-    it("'[1, -2, 3, true, \"abc\"]'",   function() {
+    cs("'[1, -2, 3, true, \"abc\"]'",   function() {
       const a = sut.asArray("[1, -2, 3, true, \"abc\"]");
       aver.isArray( a );
       aver.areArraysEquivalent([1,-2,3,true,"abc"], a);
     });
 
-    it("'[1, 2...' throws",   function() { aver.throws( function(){  sut.asArray("{1, 2..."); }, "Cast error");});
+    cs("'[1, 2...' throws",   function() { aver.throws( function(){  sut.asArray("{1, 2..."); }, "Cast error");});
 
     function Custom(){
       this[Symbol.iterator] =  function*(){
@@ -1274,7 +1274,7 @@ describe("Types", function() {
       };
     }
 
-    it("Custom Iterator",   function() {
+    cs("Custom Iterator",   function() {
       const src = new Custom();
       const a = sut.asArray( src );
       aver.isArray( a );
@@ -1284,33 +1284,33 @@ describe("Types", function() {
   });
 
 
-  describe("#cast()", function() {
+  unit("#cast()", function() {
 
-    it("()",   function() { aver.throws( function(){  sut.cast(); }, "missing 2");});
+    cs("()",   function() { aver.throws( function(){  sut.cast(); }, "missing 2");});
 
-    it("(undefined, string, false)",   function() { aver.areEqual("", sut.cast(undefined, sut.TYPE_MONIKER.STRING) );});
-    it("(undefined, string, true)",   function() { aver.areEqual(undefined, sut.cast(undefined, sut.TYPE_MONIKER.STRING, true) );});
+    cs("(undefined, string, false)",   function() { aver.areEqual("", sut.cast(undefined, sut.TYPE_MONIKER.STRING) );});
+    cs("(undefined, string, true)",   function() { aver.areEqual(undefined, sut.cast(undefined, sut.TYPE_MONIKER.STRING, true) );});
 
-    it("(3, string)",   function() { aver.areEqual("3", sut.cast(3, sut.TYPE_MONIKER.STRING) );});
-    it("(true, string)",   function() { aver.areEqual("true", sut.cast(true, sut.TYPE_MONIKER.STRING) );});
+    cs("(3, string)",   function() { aver.areEqual("3", sut.cast(3, sut.TYPE_MONIKER.STRING) );});
+    cs("(true, string)",   function() { aver.areEqual("true", sut.cast(true, sut.TYPE_MONIKER.STRING) );});
 
-    it("(true, bool)",   function() { aver.areEqual(true, sut.cast("true", sut.TYPE_MONIKER.BOOL) );});
-    it("(undefined, bool, false)",   function() { aver.areEqual(false, sut.cast(undefined, sut.TYPE_MONIKER.BOOL) );});
-    it("(undefined, bool, true)",   function() { aver.areEqual(undefined, sut.cast(undefined, sut.TYPE_MONIKER.BOOL, true) );});
-
-
-    it("(-7, int)",   function() { aver.areEqual(-7, sut.cast("-7", sut.TYPE_MONIKER.INT) );});
-
-    it("(-7.89, real)",   function() { aver.areEqual(-7.89, sut.cast("-7.89", sut.TYPE_MONIKER.REAL) );});
-
-    it("(-7.7899, money)",   function() { aver.areEqual(-7.7899, sut.cast("-7.78999999999", sut.TYPE_MONIKER.MONEY) );});
-
-    it("(Jan 1 1980, date)",   function() { aver.areEqual(1980, sut.cast("Jan 1 1980", sut.TYPE_MONIKER.DATE).getFullYear() );});
-
-    it("([1,2,3], array)",   function() { aver.areArraysEquivalent([1,2,3], sut.cast("[1,2,3]", sut.TYPE_MONIKER.ARRAY) );});
+    cs("(true, bool)",   function() { aver.areEqual(true, sut.cast("true", sut.TYPE_MONIKER.BOOL) );});
+    cs("(undefined, bool, false)",   function() { aver.areEqual(false, sut.cast(undefined, sut.TYPE_MONIKER.BOOL) );});
+    cs("(undefined, bool, true)",   function() { aver.areEqual(undefined, sut.cast(undefined, sut.TYPE_MONIKER.BOOL, true) );});
 
 
-    it("(set, array)",   function() {
+    cs("(-7, int)",   function() { aver.areEqual(-7, sut.cast("-7", sut.TYPE_MONIKER.INT) );});
+
+    cs("(-7.89, real)",   function() { aver.areEqual(-7.89, sut.cast("-7.89", sut.TYPE_MONIKER.REAL) );});
+
+    cs("(-7.7899, money)",   function() { aver.areEqual(-7.7899, sut.cast("-7.78999999999", sut.TYPE_MONIKER.MONEY) );});
+
+    cs("(Jan 1 1980, date)",   function() { aver.areEqual(1980, sut.cast("Jan 1 1980", sut.TYPE_MONIKER.DATE).getFullYear() );});
+
+    cs("([1,2,3], array)",   function() { aver.areArraysEquivalent([1,2,3], sut.cast("[1,2,3]", sut.TYPE_MONIKER.ARRAY) );});
+
+
+    cs("(set, array)",   function() {
       let s = new Set();
       s.add(100);
       s.add(-10);
@@ -1319,12 +1319,12 @@ describe("Types", function() {
     });
 
 
-    it("({a: 1, b:2}, array)",   function() { aver.areEqual(2, sut.cast("{\"a\": 1, \"b\": 2}", sut.TYPE_MONIKER.OBJECT).b );});
+    cs("({a: 1, b:2}, array)",   function() { aver.areEqual(2, sut.cast("{\"a\": 1, \"b\": 2}", sut.TYPE_MONIKER.OBJECT).b );});
   });
 
-  describe("#getRndBytes()", function() {
+  unit("#getRndBytes()", function() {
 
-    it("default",   function() {
+    cs("default",   function() {
 
       for(let i=0; i<10;i++){
         let got = sut.getRndBytes(16);
@@ -1332,11 +1332,11 @@ describe("Types", function() {
       }
     });
 
-    it("()",   function() { aver.areEqual(16, sut.getRndBytes().length) });
-    it("(0)",   function() { aver.areEqual(16, sut.getRndBytes(0).length) });
-    it("('-1')",   function() { aver.areEqual(16, sut.getRndBytes("-1").length) });
+    cs("()",   function() { aver.areEqual(16, sut.getRndBytes().length) });
+    cs("(0)",   function() { aver.areEqual(16, sut.getRndBytes(0).length) });
+    cs("('-1')",   function() { aver.areEqual(16, sut.getRndBytes("-1").length) });
 
-    it("dispersion",   function() {
+    cs("dispersion",   function() {
       const got = sut.getRndBytes(256);
       const unique = got.filter((v,i,s) => s.indexOf(v) === i);
       //console.info(got);
@@ -1348,52 +1348,52 @@ describe("Types", function() {
 
   });//getRndBytes
 
-  describe("#genGuid()", function() {
+  unit("#genGuid()", function() {
 
-    it("default",   function() {
+    cs("default",   function() {
 
       for(let i=0; i<10;i++){
         let got = sut.genGuid();
         console.log(got);
       }
     });
-    it("()",   function() { aver.throws( function(){  sut.cast(); }, "missing 2");});
+    cs("()",   function() { aver.throws( function(){  sut.cast(); }, "missing 2");});
 
   });//genGuid
 
-  describe("MinMaxBetween", function() {
+  unit("MinMaxBetween", function() {
 
-    it("atMin(123.45, 10)",   function() { aver.areEqual(123.45, sut.atMin(123.45, 10));  });
-    it("atMin(-10, 0)",   function() { aver.areEqual(0, sut.atMin(-10, 0));  });
+    cs("atMin(123.45, 10)",   function() { aver.areEqual(123.45, sut.atMin(123.45, 10));  });
+    cs("atMin(-10, 0)",   function() { aver.areEqual(0, sut.atMin(-10, 0));  });
 
-    it("atMax(123.45, 10)",   function() { aver.areEqual(10, sut.atMax(123.45, 10));  });
-    it("atMax(-10, 0)",   function() { aver.areEqual(-10, sut.atMax(-10, 0));  });
+    cs("atMax(123.45, 10)",   function() { aver.areEqual(10, sut.atMax(123.45, 10));  });
+    cs("atMax(-10, 0)",   function() { aver.areEqual(-10, sut.atMax(-10, 0));  });
 
-    it("keepBetween(15, -10, 0)",   function() { aver.areEqual(0, sut.keepBetween(15, -10, 0));  });
-    it("keepBetween(-18, -10, 0)",   function() { aver.areEqual(-10, sut.keepBetween(-18, -10, 0));  });
-    it("keepBetween(0.1, -10, 0)",   function() { aver.areEqual(0, sut.keepBetween(0.1, -10, 0));  });
-
-  });//MinMaxBetween
-
-  describe("trimUri", function() {
-
-    it("trimUri(undefined, true)",   function() { aver.areEqual(undefined, sut.trimUri(undefined, false, false, true));  });
-    it("trimUri(undefined, false)",   function() { aver.areEqual("", sut.trimUri(undefined, false, false, false));  });
-
-    it("trimUri(1)",   function() { aver.areEqual("ok", sut.trimUri(" ok "));  });
-    it("trimUri(2)",   function() { aver.areEqual("/ ok/", sut.trimUri(" / ok/ "));  });
-    it("trimUri(3)",   function() { aver.areEqual("/ok", sut.trimUri(" ok ", true));  });
-    it("trimUri(4)",   function() { aver.areEqual("ok/", sut.trimUri("  ok ", false, true));  });
-
-    it("trimUri(5)",   function() { aver.areEqual("/ok/", sut.trimUri(" /ok/", true));  });
-    it("trimUri(6)",   function() { aver.areEqual("/ok/", sut.trimUri("  /ok/ ", false, true));  });
-    it("trimUri(7)",   function() { aver.areEqual("/ok/", sut.trimUri("  ok ", true, true));  });
-
+    cs("keepBetween(15, -10, 0)",   function() { aver.areEqual(0, sut.keepBetween(15, -10, 0));  });
+    cs("keepBetween(-18, -10, 0)",   function() { aver.areEqual(-10, sut.keepBetween(-18, -10, 0));  });
+    cs("keepBetween(0.1, -10, 0)",   function() { aver.areEqual(0, sut.keepBetween(0.1, -10, 0));  });
 
   });//MinMaxBetween
 
-  describe("TimeSpanBetween", function () {
-    it("hoursBetween()", function () {
+  unit("trimUri", function() {
+
+    cs("trimUri(undefined, true)",   function() { aver.areEqual(undefined, sut.trimUri(undefined, false, false, true));  });
+    cs("trimUri(undefined, false)",   function() { aver.areEqual("", sut.trimUri(undefined, false, false, false));  });
+
+    cs("trimUri(1)",   function() { aver.areEqual("ok", sut.trimUri(" ok "));  });
+    cs("trimUri(2)",   function() { aver.areEqual("/ ok/", sut.trimUri(" / ok/ "));  });
+    cs("trimUri(3)",   function() { aver.areEqual("/ok", sut.trimUri(" ok ", true));  });
+    cs("trimUri(4)",   function() { aver.areEqual("ok/", sut.trimUri("  ok ", false, true));  });
+
+    cs("trimUri(5)",   function() { aver.areEqual("/ok/", sut.trimUri(" /ok/", true));  });
+    cs("trimUri(6)",   function() { aver.areEqual("/ok/", sut.trimUri("  /ok/ ", false, true));  });
+    cs("trimUri(7)",   function() { aver.areEqual("/ok/", sut.trimUri("  ok ", true, true));  });
+
+
+  });//MinMaxBetween
+
+  unit("TimeSpanBetween", function () {
+    cs("hoursBetween()", function () {
       const a = new Date(2024, 10, 15, 10, 0, 0, 0);
       const b = new Date(2024, 10, 15, 15, 0, 0, 0);
       aver.areEqual(sut.hoursBetween(a, b), 5);
@@ -1401,7 +1401,7 @@ describe("Types", function() {
       aver.areEqual(sut.hoursBetweenAbs(b, a), 5);
     });
 
-    it("minutesBetween()", function () {
+    cs("minutesBetween()", function () {
       const a = new Date(2024, 10, 15, 10, 0, 0, 0);
       const b = new Date(2024, 10, 15, 10, 5, 0, 0);
       aver.areEqual(sut.minutesBetween(a, b), 5);
@@ -1409,7 +1409,7 @@ describe("Types", function() {
       aver.areEqual(sut.minutesBetweenAbs(b, a), 5);
     });
 
-    it("secondsBetween()", function () {
+    cs("secondsBetween()", function () {
       const a = new Date(2024, 10, 15, 10, 0, 0, 0);
       const b = new Date(2024, 10, 15, 10, 0, 5, 0);
       aver.areEqual(sut.secondsBetween(a, b), 5);

--- a/packages/azos/test/types-tests.js
+++ b/packages/azos/test/types-tests.js
@@ -4,7 +4,6 @@
  * See the LICENSE file in the project root for more information.
 </FILE_LICENSE>*/
 
-//import { describe, it } from "mocha";
 import { defineUnit as unit, defineCase as cs } from "../run.js";
 import * as sut from "../types.js";
 import * as strings from "../strings.js";


### PR DESCRIPTION
Remove/rename remaining references to mocha's `describe` and `it` to use run.js's `unit` and `cs` method names.