### PR TITLE
Added responseBody to ClientError for UI consumption

### DIFF
--- a/packages/azos/client.js
+++ b/packages/azos/client.js
@@ -276,7 +276,8 @@ export class IClient extends Module{
 
       return result;//all OK ======================
     } catch(cause) {
-      const clErr = new ClientError(`Error calling '${method} ${uri}: ${(cause.message ?? cause)}'}`, `${this.constructor.name}.call()`, cause, cause.code ?? 599);
+      const res = cause.responseBody() ?? null;
+      const clErr = new ClientError(`Error calling '${method} ${uri}: ${(cause.message ?? cause)}'}`, `${this.constructor.name}.call()`, cause, cause.code ?? 599, res);
       this.writeLog(LOG_TYPE.TRACE, "Error making client call", clErr, {method, uri});
       throw clErr;
     }


### PR DESCRIPTION
Server side error details are in the responseBody and need passed along to the caller to display any server side validation errors to the user. 