### PR TITLE
sticky-container util

### DIFF
--- a/packages/azos-ui/test/examples/showcase-applet.js
+++ b/packages/azos-ui/test/examples/showcase-applet.js
@@ -40,6 +40,7 @@ import "../showcase/case-tree-view-n.js";
 import "../showcase/case-launcher.js";
 import "../showcase/case-cards.js";
 import "../showcase/case-grids.js";
+import "../showcase/case-sticky-container.js";
 import "../showcase/case-prose.js";
 import "../showcase/case-grid-split.js";
 import "../showcase/case-schema-bit.js";
@@ -144,6 +145,7 @@ export class ShowcaseApplet extends Applet {
       <option value="Selects">Selects</option>
       <option value="Sizing">Sizing</option>
       <option value="SlideDeck">Slide Deck</option>
+      <option value="StickyContainer">Sticky Container</option>
       <option value="Switches">Switches</option>
       <option value="TabView">Tab View</option>
       <option value="TextFields">Text Fields</option>
@@ -192,6 +194,7 @@ export class ShowcaseApplet extends Applet {
       Sizing: html`<az-case-sizing></az-case-sizing>`,
       SlideDeck: html`<az-case-slide-deck></az-case-slide-deck>`,
       ScheduleSpan: html`<az-case-model-schedule-span></az-case-model-schedule-span>`,
+      StickyContainer: html`<az-case-sticky-container></az-case-sticky-container>`,
       Switches: html`<az-case-switches></az-case-switches>`,
       TabView: html`<az-case-tab-view></az-case-tab-view>`,
       TextFields: html`<az-case-text-fields></az-case-text-fields>`,

--- a/packages/azos-ui/test/showcase/case-sticky-container.js
+++ b/packages/azos-ui/test/showcase/case-sticky-container.js
@@ -1,0 +1,37 @@
+/*<FILE_LICENSE>
+ * Azos (A to Z Application Operating System) Framework
+ * The A to Z Foundation (a.k.a. Azist) licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+</FILE_LICENSE>*/
+
+import { html } from "../../ui";
+import { CaseBase } from "./case-base";
+
+import STL_CARD from "../../styles/card";
+import "../../parts/grid-split";
+import STL_INLINE_GRID from "../../styles/grid";
+import "../../vcl/util/sticky-container";
+
+export class CaseStickyContainer extends CaseBase {
+
+  static styles = [ this.styles, STL_INLINE_GRID, STL_CARD];
+
+  renderControl() {
+    return html`
+      <h3>Sticky Container in Grid Split</h3>
+      <az-grid-split scope="this" splitLeftCols="1" splitRightCols="3">
+        <div slot="left-top">
+          <az-sticky-container top="60" minWidth="600">
+            <div class="card">Left Top Content</div>
+          </az-sticky-container>
+        </div>
+        <div slot="right-bottom">
+          <div class="card">Tall Right Bottom Content</div>
+          <div style="height: 200vh; overflow: auto;"></div>
+        </div>
+      </az-grid-split>
+    `;
+  }
+}
+
+window.customElements.define("az-case-sticky-container", CaseStickyContainer);

--- a/packages/azos-ui/vcl/cforest/explorer-applet.js
+++ b/packages/azos-ui/vcl/cforest/explorer-applet.js
@@ -8,6 +8,7 @@ import { Spinner } from "../../spinner";
 import "../../bit";
 
 import "../util/code-box";
+import "../util/sticky-container";
 import "../tabs/tab-view";
 import "../tabs/tab";
 
@@ -64,21 +65,35 @@ export class ForestExplorerApplet extends Applet  {
       flex: 1;
     }
 
-    .minHeightEnforced {
-      min-height: 60vh;
+    .scrollerTitle {
+      padding: 0.5em 0.5em 0 0.5em;
+    }
+
+    .tvScroller {
+      max-height: calc(100vh - 14.5em);
+      min-height: 50vh;
+      overflow: auto;
+      margin: 0;
+      padding: 0 1em;
     }
 
     @media (max-width: 600px) {
-      .minHeightEnforced {
-        min-height: auto; /* Override for small screens */
+      .tvScroller {
+        min-height: auto;
+        max-height: 24vh;
       }
-   }
+      .maxHeightEnforced {
+        min-height: auto;
+        max-height: auto;
+      }
+    }
+
   `];
 
   #client = null;
 
   // Holds the forests and their trees
-  // will be updated after the firstUp2dated
+  // will be updated after the firstUpdated
   #forests = [];
   get forests() { return this.#forests; }
   set forests(value) { this.#forests = value; }
@@ -215,7 +230,9 @@ export class ForestExplorerApplet extends Applet  {
       this.requestUpdate();
       this.arena.requestUpdate();
     }, "Loading forests/trees");
+  }
 
+  disconnectedCallback(){
 
   }
 
@@ -491,8 +508,8 @@ export class ForestExplorerApplet extends Applet  {
   render(){
     const asOfDisplay = this.activeAsOfUtc;
     const showAsOf = !this.activeAsOfUtc
-      ? html`<div class=""><strong>As of Utc: </strong></span>Now</div>`
-      : html`<div class=""><span class="asOfUtc" @click="${() => this.#forestSettingsCmd.exec(this.arena)}"><strong>As of: </strong>${this.formatDT(asOfDisplay)} UTC</span></div>`;
+      ? html`<div class="scrollerTitle"><strong>As of Utc: </strong></span>Now</div>`
+      : html`<div class="scrollerTitle"><span class="asOfUtc" @click="${() => this.#forestSettingsCmd.exec(this.arena)}"><strong>As of: </strong>${this.formatDT(asOfDisplay)} UTC</span></div>`;
 
     return html`
       <az-forest-settings-dialog id="dlgSettings" scope="this" title="Explorer Settings" .settings="${{
@@ -509,13 +526,23 @@ export class ForestExplorerApplet extends Applet  {
         .onCFSettingsClick="${() => this.#forestSettingsCmd.exec(this.arena)}"
       ></az-cforest-breadcrumbs>
 
-      <az-grid-split id="splitGridView" scope="this" splitLeftCols="4" splitRightCols="8">
+      <az-grid-split id="splitGridView" scope="this" splitLeftCols="4" splitRightCols="8" .onResized="${() => this.adjustStickyWidth()}">
         <div slot="left-top">
-          <div class="cardBasic">
-            ${showAsOf}<hr style="opacity: 0.5;"/>
-            <az-tree-view-n id="tvExplorer" scope="this" class="minHeightEnforced"></az-tree-view-n>
-          </div>
+
+          <az-sticky-container top="60" minWidth="600">
+            <div class="cardBasic">
+              ${showAsOf}<hr style="opacity: 0.5;"/>
+              <az-tree-view-n id="tvExplorer" scope="this" class="tvScroller"></az-tree-view-n>
+            </div>
+
+          </az-sticky-container>
+
+
+
+
         </div>
+
+
         <div slot="right-bottom">
 
           <div class="cardBasic">
@@ -531,16 +558,16 @@ export class ForestExplorerApplet extends Applet  {
           </div>
 
           <az-tab-view title="Draggable TabView" activeTabIndex="0" isDraggable>
-            <az-tab title="Selected Node" .canClose="${false}">
+            <az-tab title="Selected Node" .canClose="${false}" class="maxHeightEnforced">
               <az-code-box id="objectInspector0" scope="self" highlight="json" .source=${JSON.stringify(this.#activeNodeData, null, 2)}></az-code-box>
             </az-tab>
-            <az-tab title="Level Config" .canClose="${false}">
+            <az-tab title="Level Config" .canClose="${false}" class="maxHeightEnforced">
               <az-code-box id="objectInspector1" scope="self" highlight="json" .source=${this.formatCV(this.#activeNodeData?.LevelConfig)}></az-code-box>
             </az-tab>
-            <az-tab title="Effective Config" .canClose="${false}">
+            <az-tab title="Effective Config" .canClose="${false}" class="maxHeightEnforced">
               <az-code-box id="objectInspector2" scope="self" highlight="json" .source=${this.formatCV(this.#activeNodeData?.EffectiveConfig)}></az-code-box>
             </az-tab>
-            <az-tab title="Properties" .canClose="${false}">
+            <az-tab title="Properties" .canClose="${false}" class="maxHeightEnforced">
               <az-code-box id="objectInspector3" scope="self" highlight="json" .source=${this.formatCV(this.#activeNodeData?.Properties)}></az-code-box>
             </az-tab>
           </az-tab-view>

--- a/packages/azos-ui/vcl/cforest/explorer-applet.js
+++ b/packages/azos-ui/vcl/cforest/explorer-applet.js
@@ -56,15 +56,6 @@ export class ForestExplorerApplet extends Applet  {
       overflow: auto;
     }
 
-    .horizontalBtnBar {
-      display: flex;
-      width: 100%;
-    }
-
-    .horizontalBtnBar az-button {
-      flex: 1;
-    }
-
     .scrollerTitle {
       padding: 0.5em 0.5em 0 0.5em;
     }
@@ -87,7 +78,6 @@ export class ForestExplorerApplet extends Applet  {
         max-height: auto;
       }
     }
-
   `];
 
   #client = null;
@@ -230,10 +220,6 @@ export class ForestExplorerApplet extends Applet  {
       this.requestUpdate();
       this.arena.requestUpdate();
     }, "Loading forests/trees");
-  }
-
-  disconnectedCallback(){
-
   }
 
   /**
@@ -528,20 +514,15 @@ export class ForestExplorerApplet extends Applet  {
 
       <az-grid-split id="splitGridView" scope="this" splitLeftCols="4" splitRightCols="8" .onResized="${() => this.adjustStickyWidth()}">
         <div slot="left-top">
-
           <az-sticky-container top="60" minWidth="600">
+
             <div class="cardBasic">
               ${showAsOf}<hr style="opacity: 0.5;"/>
               <az-tree-view-n id="tvExplorer" scope="this" class="tvScroller"></az-tree-view-n>
             </div>
 
           </az-sticky-container>
-
-
-
-
         </div>
-
 
         <div slot="right-bottom">
 

--- a/packages/azos-ui/vcl/cforest/node-summary.js
+++ b/packages/azos-ui/vcl/cforest/node-summary.js
@@ -2,6 +2,8 @@ import { html, css, Control } from "../../ui";
 import { toast } from "../../toast";
 import { writeToClipboard } from "../util/clipboard";
 import "./node-dialog";
+import { Button } from "../../parts/button";
+import { baseStyles, buttonStyles, iconStyles } from "../../parts/styles";
 
 /**
  * Component for displaying a summary of a selected node in a forest context.
@@ -24,6 +26,7 @@ class ForestNodeSummary extends Control {
       justify-content: flex-start;
       gap: 0.5em;
       margin-bottom: 0;
+      container: buttonbar / inline-size;
     }
 
     .btnSettings {
@@ -77,9 +80,9 @@ class ForestNodeSummary extends Control {
           <h6>${this.source?.DataVersion?.Utc} (${this.source?.DataVersion?.State})</h6>
         </div>
         <div>
-          <az-button id="btnAddNode"  title="Add Node"    rank="4" class="selectedNodeBtn" position="left" icon="svg://azos.ico.add" @click="${(e) => this.#addNode(this.source)}">Add</az-button>
-          <az-button id="btnEditNode" title="Edit Node"   rank="4" class="selectedNodeBtn" position="left" icon="svg://azos.ico.edit" @click="${(e) => this.#editNode(this.source)}">Edit</az-button>
-          <az-button id="btnVersions" title="Versions..." rank="4" class="selectedNodeBtn" position="left" icon="svg://azos.ico.calendarToday" @click="${(e) => this.openVersions()}">Edit</az-button>
+          <az-contained-button id="btnAddNode"  title="Add Node"    rank="4" class="selectedNodeBtn" position="left" icon="svg://azos.ico.add" @click="${(e) => this.#addNode(this.source)}">Add</az-contained-button>
+          <az-contained-button id="btnEditNode" title="Edit Node"   rank="4" class="selectedNodeBtn" position="left" icon="svg://azos.ico.edit" @click="${(e) => this.#editNode(this.source)}">Edit</az-contained-button>
+          <az-contained-button id="btnVersions" title="Versions..." rank="4" class="selectedNodeBtn" position="left" icon="svg://azos.ico.calendarToday" @click="${(e) => this.openVersions()}">Edit</az-contained-button>
         </div>
       </div>
 
@@ -90,3 +93,22 @@ class ForestNodeSummary extends Control {
 }
 
 window.customElements.define("az-cforest-summary", ForestNodeSummary);
+
+// buttons that shrink when the container "buttonbar" is narrow
+class ContainedButton extends Button {
+  static styles = [ baseStyles, buttonStyles, iconStyles, css`
+    :host { margin: 0; }
+    button .icon { width: var(--icon-size); }
+    @container buttonbar (width < 640px) {
+      button {
+        padding: 7px;
+        margin: 0px;
+        & span { display: none; }
+      }
+
+      button .icon { margin:0; width: var(--icon-size); }
+    }
+  `];
+}
+
+window.customElements.define("az-contained-button", ContainedButton);

--- a/packages/azos-ui/vcl/util/sticky-container.js
+++ b/packages/azos-ui/vcl/util/sticky-container.js
@@ -1,0 +1,123 @@
+/*<FILE_LICENSE>
+ * Azos (A to Z Application Operating System) Framework
+ * The A to Z Foundation (a.k.a. Azist) licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+</FILE_LICENSE>*/
+
+import { Control, css, html } from "../../ui";
+
+/** Provides a container that "sticks" when scrolling */
+export class StickyContainer extends Control {
+
+  static styles = css` :host { padding:0; margin:0; }`;
+  static properties = {
+    top: { type: Number },
+    minWidth: { type: Number }, // below this width sticky is disabled
+    selector: { type: String }
+  };
+
+  #placeholder = null;
+  #resizeObserver = null;
+  #isFixed = false;
+  #startingOffset = 0;
+
+  #scrollListener = null;
+  #resizeListener = null;
+
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    if(this.top === undefined) this.top = 0;
+    if(this.minWidth === undefined) this.minWidth = 600; // default min width for sticky
+
+    // create a placeholder to retain the current layout
+    this.#placeholder = document.createElement("div");
+
+    if(!this.#scrollListener)this.#scrollListener = window.addEventListener("scroll", () => {
+      if(window.scrollY >= this.#startingOffset) {
+          if(!this.#isFixed && window.innerWidth >= this.minWidth) this.fix();
+      } else if(this.#isFixed) {
+          this.unfix();
+      }
+    }, { passive: true });
+
+    if(!this.#resizeListener) this.#resizeListener = window.addEventListener("resize", () => {
+       if(!this.#isFixed) return;
+      const r = this.#placeholder.getBoundingClientRect();
+      this.style.left = `${Math.floor(r.left)}px`;
+      this.style.width = `${Math.floor(r.width)}px`;
+    }, { passive: true });
+  }
+
+  firstUpdated() {
+    this.#startingOffset = this.getBoundingClientRect().top + window.scrollY - (this.top ?? 0);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if(this.#scrollListener) window.removeEventListener("scroll", this.#scrollListener);
+    if(this.#resizeListener) window.removeEventListener("resize", this.#resizeListener);
+    this.stopResizeListener();
+    this.#placeholder = null;
+  }
+
+  // fix into place
+  fix(){
+    const rect = this.getBoundingClientRect();
+    // reduce jumping of the layout
+    this.#placeholder.style.height = `${rect.height}px`;
+    if(!this.#placeholder.parentElement) this.parentElement.insertBefore(this.#placeholder, this);
+
+    this.style.position = "fixed";
+    this.style.top = `${Math.floor(this.top)}px`;
+    this.style.left = `${Math.floor(rect.left)}px`;
+    this.style.width = `${Math.floor(rect.width)}px`;
+    this.style.zIndex = "1000"; // ensure it's above other elements
+
+    this.#isFixed = true;
+
+    this.startResizeListener();
+  }
+
+  // unfix and restore
+  unfix() {
+    this.stopResizeListener();
+    if(this.#placeholder.parentElement)  this.#placeholder.remove();
+    this.style.position = "";
+    this.style.top = "";
+    this.style.left = "";
+    this.style.width = "";
+    this.style.zIndex = "";
+    this.#isFixed = false;
+  }
+
+  startResizeListener(){
+    if(!this.#placeholder || this.#resizeObserver) return;
+    this.#resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        // If the placeholder is resized, adjust the sticky container width
+        if(entry.target === this.#placeholder) {
+          const r = this.#placeholder.getBoundingClientRect();
+          this.style.width = `${Math.floor(r.width)}px`;
+        }
+      }
+    });
+    this.#resizeObserver.observe(this.#placeholder);
+  }
+
+  stopResizeListener(){
+    if(!this.#resizeObserver) return;
+    this.#resizeObserver.disconnect();
+    this.#resizeObserver = null;
+  }
+
+  renderControl() {
+    return html`<slot></slot>`;
+  }
+}
+
+window.customElements.define("az-sticky-container", StickyContainer);


### PR DESCRIPTION
The sticky-container wraps an element and will fix the content on the screen when scrolling past the original location and unfix the content when original location fully scrolled into view. This will work regardless of the parent element layout and is less brittle then the pure css solution.