### PR TITLE
client test for responseBody on error

### DIFF
--- a/packages/azos/client.js
+++ b/packages/azos/client.js
@@ -276,7 +276,7 @@ export class IClient extends Module{
 
       return result;//all OK ======================
     } catch(cause) {
-      const res = cause.responseBody() ?? null;
+      const res = types.isFunction(cause?.responseBody) ? cause.responseBody() : null;
       const clErr = new ClientError(`Error calling '${method} ${uri}: ${(cause.message ?? cause)}'}`, `${this.constructor.name}.call()`, cause, cause.code ?? 599, res);
       this.writeLog(LOG_TYPE.TRACE, "Error making client call", clErr, {method, uri});
       throw clErr;


### PR DESCRIPTION
While testing I found that if the responseBody didn't exist/wasn't a function the error displayed was about the responseBody not being a fn instead of the generic message as expected. 